### PR TITLE
Desyncbug

### DIFF
--- a/core/peer_networked_controller.cpp
+++ b/core/peer_networked_controller.cpp
@@ -1195,6 +1195,7 @@ bool DollController::receive_inputs(const std::vector<uint8_t> &p_data) {
 				SCParseTmpData *pd = static_cast<SCParseTmpData *>(p_user_pointer);
 				NS_ASSERT_COND(p_frame_index != FrameIndex::NONE);
 				if (pd->controller.last_doll_validated_input != FrameIndex::NONE && pd->controller.last_doll_validated_input >= p_frame_index) {
+					// This input is already processed.
 					return;
 				}
 

--- a/core/peer_networked_controller.cpp
+++ b/core/peer_networked_controller.cpp
@@ -1193,16 +1193,8 @@ bool DollController::receive_inputs(const std::vector<uint8_t> &p_data) {
 			// Parse the Input:
 			[](void *p_user_pointer, FrameIndex p_frame_index, std::uint16_t p_input_size_in_bits, const BitArray &p_bit_array) -> void {
 				SCParseTmpData *pd = static_cast<SCParseTmpData *>(p_user_pointer);
-				if (pd->controller.peer_controller->authority_peer == 3) {
-					SceneSynchronizerDebugger::singleton()->print(WARNING, "Received doll input: " + p_frame_index);
-				}
-
 				NS_ASSERT_COND(p_frame_index != FrameIndex::NONE);
 				if (pd->controller.last_doll_validated_input != FrameIndex::NONE && pd->controller.last_doll_validated_input >= p_frame_index) {
-					// This input is already processed.
-					if (pd->controller.peer_controller->authority_peer == 3) {
-						SceneSynchronizerDebugger::singleton()->print(WARNING, "discarded: " + p_frame_index);
-					}
 					return;
 				}
 
@@ -1352,9 +1344,6 @@ bool DollController::fetch_next_input(float p_delta) {
 
 void DollController::process(float p_delta) {
 	const bool is_new_input = fetch_next_input(p_delta);
-	if (peer_controller->authority_peer == 3) {
-		SceneSynchronizerDebugger::singleton()->print(WARNING, "---- The processing input: " + get_current_frame_index() + " --- the queue instant to process: " + std::to_string(queued_instant_to_process) + " is_new_input: " + std::string(is_new_input ? "true" : "false"));
-	}
 
 	if make_likely(current_input_buffer_id > FrameIndex{ { 0 } }) {
 		// This operation is done here, because the doll process on a different

--- a/core/peer_networked_controller.cpp
+++ b/core/peer_networked_controller.cpp
@@ -1259,7 +1259,7 @@ int DollController::fetch_optimal_queued_inputs() const {
 	//
 	// TODO: At the moment this value is fixed to the min_frame_delay, but at some
 	// point we will want to change this value dynamically depending on packet loss.
-	return peer_controller->scene_synchronizer->get_min_server_input_buffer_size();
+	return peer_controller->scene_synchronizer->get_min_doll_input_buffer_size();
 }
 
 bool DollController::fetch_next_input(float p_delta) {

--- a/core/peer_networked_controller.h
+++ b/core/peer_networked_controller.h
@@ -36,7 +36,7 @@ struct NoNetController;
 // The most important part is inside the `PlayerController`, `ServerController`,
 // `DollController`, `NoNetController`.
 class PeerNetworkedController final {
-	friend class NS::SceneSynchronizerBase;
+	friend class SceneSynchronizerBase;
 	template <class NetInterfaceClass>
 	friend class NetworkedController;
 	friend struct RemotelyControlledController;
@@ -69,14 +69,14 @@ private:
 	Controller *controller = nullptr;
 	DataBuffer inputs_buffer;
 
-	NS::SceneSynchronizerBase *scene_synchronizer = nullptr;
+	SceneSynchronizerBase *scene_synchronizer = nullptr;
 
 	bool are_controllable_objects_sorted = false;
 	std::vector<ObjectData *> _sorted_controllable_objects;
 
 	bool has_player_new_input = false;
 
-	NS::PHandler event_handler_peer_status_updated = NS::NullPHandler;
+	PHandler event_handler_peer_status_updated = NullPHandler;
 
 public: // -------------------------------------------------------------- Events
 	Processor<> event_controller_reset;

--- a/scene_synchronizer.cpp
+++ b/scene_synchronizer.cpp
@@ -3968,7 +3968,7 @@ void ClientSynchronizer::apply_snapshot(
 		const bool p_skip_change_event) {
 	NS_PROFILE
 
-	const std::vector<NS::NameAndVar> *snap_objects_vars = p_snapshot.object_vars.data();
+	const std::vector<NameAndVar> *snap_objects_vars = p_snapshot.object_vars.data();
 
 	if (!p_skip_change_event) {
 		scene_synchronizer->change_events_begin(p_flag);
@@ -3980,7 +3980,7 @@ void ClientSynchronizer::apply_snapshot(
 	}
 
 	for (const SimulatedObjectInfo &info : p_snapshot.simulated_objects) {
-		NS::ObjectData *object_data = scene_synchronizer->get_object_data(info.net_id);
+		ObjectData *object_data = scene_synchronizer->get_object_data(info.net_id);
 
 		if (object_data == nullptr) {
 			// This can happen, and it's totally expected, because the server

--- a/scene_synchronizer.h
+++ b/scene_synchronizer.h
@@ -212,6 +212,9 @@ protected: // --------------------------------------------------------- Settings
 	int min_server_input_buffer_size = 2;
 	int max_server_input_buffer_size = 7;
 
+	int min_doll_input_buffer_size = 2;
+	int max_doll_input_buffer_size = 7;
+
 	/// Negligible packet loss we can just ignore.
 	float negligible_packet_loss = 0.001f;
 
@@ -264,7 +267,7 @@ protected: // -------------------------------------------------------- Internals
 
 	// Controller RPCs.
 	RpcHandle<int, const std::vector<std::uint8_t> &> rpc_handle_receive_input;
-	
+
 	Settings settings;
 	bool settings_changed = true;
 
@@ -388,6 +391,22 @@ public:
 	void set_max_server_input_buffer_size(int p_val);
 	int get_max_server_input_buffer_size() const;
 
+	void set_min_doll_input_buffer_size(int p_val) {
+		min_doll_input_buffer_size = p_val;
+	}
+
+	int get_min_doll_input_buffer_size() const {
+		return min_doll_input_buffer_size;
+	}
+
+	void set_max_doll_input_buffer_size(int p_val) {
+		min_doll_input_buffer_size = p_val;
+	}
+
+	int get_max_doll_input_buffer_size() const {
+		return max_doll_input_buffer_size;
+	}
+
 	void set_negligible_packet_loss(float p_val);
 	float get_negligible_packet_loss() const;
 
@@ -501,7 +520,7 @@ public: // ---------------------------------------------------------------- APIs
 	void untrack_variable_changes(ListenerHandle p_handle);
 
 	/// You can use the macro `callable_mp()` to register custom C++ function.
-	NS::PHandler register_process(ObjectLocalId p_id, ProcessPhase p_phase, std::function<void(float)> p_func);
+	PHandler register_process(ObjectLocalId p_id, ProcessPhase p_phase, std::function<void(float)> p_func);
 	void unregister_process(ObjectLocalId p_id, ProcessPhase p_phase, NS::PHandler p_func_handler);
 
 	/// Setup the trickled sync method for this specific object.
@@ -527,7 +546,7 @@ public: // ---------------------------------------------------------------- APIs
 	SyncGroupId sync_group_create();
 
 	/// IMPORTANT: The pointer returned is invalid at the end of the scope executing this function. Never store it.
-	const NS::SyncGroup *sync_group_get(SyncGroupId p_group_id) const;
+	const SyncGroup *sync_group_get(SyncGroupId p_group_id) const;
 
 	void sync_group_add_object(ObjectLocalId p_id, SyncGroupId p_group_id, bool p_realtime);
 	void sync_group_add_object(ObjectNetId p_id, SyncGroupId p_group_id, bool p_realtime);

--- a/scene_synchronizer.h
+++ b/scene_synchronizer.h
@@ -400,7 +400,7 @@ public:
 	}
 
 	void set_max_doll_input_buffer_size(int p_val) {
-		min_doll_input_buffer_size = p_val;
+		max_doll_input_buffer_size = p_val;
 	}
 
 	int get_max_doll_input_buffer_size() const {

--- a/tests/test_doll_simulation.cpp
+++ b/tests/test_doll_simulation.cpp
@@ -15,7 +15,7 @@
 #include <thread>
 
 namespace NS_Test {
-int frame_per_seconds = 60;
+int frames_per_seconds = 60;
 
 std::shared_ptr<NS::LocalSceneSynchronizerNoSubTicks> SceneSyncNoSubTicks_Obj1;
 std::shared_ptr<NS::LocalSceneSynchronizerNoSubTicks> SceneSyncNoSubTicks_Obj2;
@@ -193,9 +193,9 @@ public:
 					peer_2_scene.add_existing_object(SceneSync_Obj3, "sync", server_scene.get_peer());
 		}
 
-		server_scene.scene_sync->set_frames_per_seconds(frame_per_seconds);
-		peer_1_scene.scene_sync->set_frames_per_seconds(frame_per_seconds);
-		peer_2_scene.scene_sync->set_frames_per_seconds(frame_per_seconds);
+		server_scene.scene_sync->set_frames_per_seconds(frames_per_seconds);
+		peer_1_scene.scene_sync->set_frames_per_seconds(frames_per_seconds);
+		peer_2_scene.scene_sync->set_frames_per_seconds(frames_per_seconds);
 
 		server_scene.scene_sync->set_frame_confirmation_timespan(frame_confirmation_timespan);
 
@@ -703,9 +703,6 @@ void test_simulation_with_hiccups(TestDollSimulationStorePositions &test) {
 
 void test_simulation_with_latency() {
 	TestDollSimulationStorePositions test;
-	test.server_scene.scene_sync->set_frames_per_seconds(frame_per_seconds);
-	test.peer_1_scene.scene_sync->set_frames_per_seconds(frame_per_seconds);
-	test.peer_2_scene.scene_sync->set_frames_per_seconds(frame_per_seconds);
 
 	test.frame_confirmation_timespan = 1.0f / 10.0f;
 	// NOTICE: Disabling sub ticks because these cause some additional and
@@ -912,6 +909,7 @@ void test_doll_simulation() {
 	SceneSync_Obj2 = std::make_shared<NS::LocalSceneSynchronizer>();
 	SceneSync_Obj3 = std::make_shared<NS::LocalSceneSynchronizer>();
 
+	const int initial_frames_per_seconds = frames_per_seconds;
 	for (int i = 0; i < 3; i++) {
 		test_simulation_without_reconciliation(0.0f);
 		test_simulation_without_reconciliation(1.f / 30.f);
@@ -919,10 +917,13 @@ void test_doll_simulation() {
 		test_simulation_reconciliation(0.0001f);
 		test_simulation_reconciliation(1.0f / 10.0f);
 		test_simulation_world_object_reconciliation(0.0f);
-		test_simulation_world_object_reconciliation(1.0f / float(frame_per_seconds));
+		test_simulation_world_object_reconciliation(1.0f / float(frames_per_seconds));
 		test_simulation_world_object_reconciliation(1.f / 10.0f);
-		frame_per_seconds *= 2;
+		frames_per_seconds *= 2;
 	}
+
+	frames_per_seconds = initial_frames_per_seconds;
+
 	test_simulation_with_latency();
 	test_simulation_with_hiccups();
 	test_simulation_with_wrong_input();

--- a/tests/test_doll_simulation.cpp
+++ b/tests/test_doll_simulation.cpp
@@ -15,7 +15,7 @@
 #include <thread>
 
 namespace NS_Test {
-const int frame_per_seconds = 240;
+int frame_per_seconds = 60;
 
 std::shared_ptr<NS::LocalSceneSynchronizerNoSubTicks> SceneSyncNoSubTicks_Obj1;
 std::shared_ptr<NS::LocalSceneSynchronizerNoSubTicks> SceneSyncNoSubTicks_Obj2;
@@ -449,7 +449,7 @@ struct TestDollSimulationStorePositions : public TestDollSimulationBase {
 		for (NS::FrameIndex i = NS::FrameIndex{ { 0 } }; i <= biggest_frame_index; i += 1) {
 			const NS::VarData *player_position = NS::MapFunc::get_or_null(p_player_map, i);
 			const NS::VarData *doll_position = NS::MapFunc::get_or_null(p_doll_map, i);
-			if (i > assert_after) {
+			if (i > assert_after && player_position) {
 				NS_ASSERT_COND(player_position);
 				NS_ASSERT_COND(doll_position);
 				NS_ASSERT_COND(NS::LocalSceneSynchronizer::var_data_compare(*player_position, *doll_position));
@@ -912,19 +912,22 @@ void test_doll_simulation() {
 	SceneSync_Obj2 = std::make_shared<NS::LocalSceneSynchronizer>();
 	SceneSync_Obj3 = std::make_shared<NS::LocalSceneSynchronizer>();
 
-	//test_simulation_without_reconciliation(0.0f);
-	//test_simulation_without_reconciliation(1.f / 30.f);
-	//test_simulation_reconciliation(0.0f);
-	//test_simulation_reconciliation(0.0001);
-	//test_simulation_reconciliation(1.0f / 10.0f);
-	//test_simulation_world_object_reconciliation(0.0f);
-	//test_simulation_world_object_reconciliation(1.0f / float(frame_per_seconds));
-	//test_simulation_world_object_reconciliation(1.f / 10.0f);
-	//test_simulation_with_latency();
-	//test_simulation_with_hiccups();
-	//test_simulation_with_wrong_input();
+	for (int i = 0; i < 3; i++) {
+		test_simulation_without_reconciliation(0.0f);
+		test_simulation_without_reconciliation(1.f / 30.f);
+		test_simulation_reconciliation(0.0f);
+		test_simulation_reconciliation(0.0001f);
+		test_simulation_reconciliation(1.0f / 10.0f);
+		test_simulation_world_object_reconciliation(0.0f);
+		test_simulation_world_object_reconciliation(1.0f / float(frame_per_seconds));
+		test_simulation_world_object_reconciliation(1.f / 10.0f);
+		frame_per_seconds *= 2;
+	}
+	test_simulation_with_latency();
+	test_simulation_with_hiccups();
+	test_simulation_with_wrong_input();
 	//// TODO test with great latency and lag compensation.
-	//test_latency();
+	test_latency();
 
 	SceneSyncNoSubTicks_Obj1->clear_scene();
 	SceneSyncNoSubTicks_Obj2->clear_scene();

--- a/tests/test_doll_simulation.cpp
+++ b/tests/test_doll_simulation.cpp
@@ -265,20 +265,7 @@ public:
 					peer_1_scene.process(rand_delta);
 				}
 				if (p_process_peer2) {
-					// TODO remove, this is just a trigger for my breakpoint
-					const NS::ObjectLocalId doll_id = controlled_1_peer2->local_id;
-					const NS::FrameIndex controller_1_doll_frame_index = peer_2_scene.scene_sync->get_controller_for_peer(peer_1_scene.get_peer())->get_current_frame_index();
-					if (controller_1_doll_frame_index != NS::FrameIndex::NONE && controller_1_doll_frame_index.id >= 45) {
-						peer_2_scene.scene_sync->__print_line("The Frame.");
-					}
-
 					peer_2_scene.process(rand_delta);
-
-					// TODO remove
-					const NS::FrameIndex controller_1_doll_frame_index_post = peer_2_scene.scene_sync->get_controller_for_peer(peer_1_scene.get_peer())->get_current_frame_index();
-					if (controller_1_doll_frame_index != NS::FrameIndex::NONE && controller_1_doll_frame_index_post != NS::FrameIndex::NONE && controller_1_doll_frame_index >= controller_1_doll_frame_index_post) {
-						peer_2_scene.scene_sync->__print_line("It  went back.");
-					}
 				}
 			}
 
@@ -620,11 +607,9 @@ void test_simulation_world_object_reconciliation(float p_frame_confirmation_time
 	test.controlled_1_peer2->set_xy(.0, .0); // Modify the doll on peer 2
 	test.scene_object_peer2->set_xy(.0, .0);
 
-	// TODO enable this loop
-	// Process this another 4 times to ensure no
+	// Process this another 3 times to ensure no
 	// other desync occurred and all the frames are being processed
-	//for (int i = 0; i < 4; i++)
-	{
+	for (int i = 0; i < 3; i++) {
 		// Run another 30 frames.
 		test.do_test(30);
 
@@ -927,7 +912,7 @@ void test_doll_simulation() {
 	test_simulation_with_latency();
 	test_simulation_with_hiccups();
 	test_simulation_with_wrong_input();
-	//// TODO test with great latency and lag compensation.
+	// TODO test with great latency and lag compensation.
 	test_latency();
 
 	SceneSyncNoSubTicks_Obj1->clear_scene();


### PR DESCRIPTION
Adds some more test on the doll sync to verify that the sync works correctly even when a world object is desync.
Also, tests the same scenarios with different processing Hz (60 and 120), to ensure everything works independently from the processing Hz.