### PR TITLE
Refactors the SceneSynchronizerDebugger

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -24,6 +24,26 @@ option(USE_STATIC_MSVC_RUNTIME_LIBRARY "Use the static MSVC runtime library" ON)
 # Windows Store only supports the DLL version
 option(BUILD_MSVC_MD "In MSVC build the library using MD." ON)
 
+# TODO please turn this off by default
+option(ENABLE_DEBUGGER_UI "Enables the debugger UI." OFF)
+
+if(ENABLE_DEBUGGER_UI)
+    # Find Python interpreter used to load the debugger_ui into C++.
+    find_package(Python3 COMPONENTS Interpreter REQUIRED)
+
+    # Command to execute the Python script
+    add_custom_command(
+        OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/../core/__generated__debugger_ui.h
+        COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/../debugger_ui/cpplize_debugger.py ${CMAKE_CURRENT_SOURCE_DIR}/..
+        COMMENT "Running Python script to generate the __generated__debugger_ui.h file"
+    )
+    
+    # Include the generated file as part of the build dependencies
+    add_custom_target(RunPythonScript ALL
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/../core/__generated__debugger_ui.h
+    )
+endif()
+
 if (MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /fp:precise") # Ensure floating point is not fast to make math operations deterministic.
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /fp:precise") # Ensure floating point is not fast to make math operations deterministic.
@@ -132,6 +152,11 @@ set(NS_SRC_FILES
 	${NS_ROOT}/tests/tests.cpp
 	${NS_ROOT}/tests/tests.h
 )
+
+if(ENABLE_DEBUGGER_UI)
+    add_compile_definitions(UI_DEBUGGER_ENABLED)
+    list(APPEND NS_SRC_FILES ${NS_ROOT}/core/__generated__debugger_ui.h)
+endif()
 	
 # Group source files
 source_group(TREE ${NS_ROOT} FILES ${NS_SRC_FILES})
@@ -148,4 +173,8 @@ endif()
 
 if (ENABLE_DEBUG_DATA_BUFFER)
 	target_compile_definitions(NetworkSynchronizer PUBLIC DEBUG_DATA_BUFFER)
+endif()
+
+if(ENABLE_DEBUGGER_UI)
+    add_dependencies(NetworkSynchronizer RunPythonScript)
 endif()

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -24,7 +24,7 @@ option(USE_STATIC_MSVC_RUNTIME_LIBRARY "Use the static MSVC runtime library" ON)
 # Windows Store only supports the DLL version
 option(BUILD_MSVC_MD "In MSVC build the library using MD." ON)
 
-# TODO please turn this off by default
+# Enables the debugger UI. Allows to debug the data sent and received by any peers to identify bugs.
 option(ENABLE_DEBUGGER_UI "Enables the debugger UI." OFF)
 
 if(ENABLE_DEBUGGER_UI)

--- a/core/bit_array.cpp
+++ b/core/bit_array.cpp
@@ -5,12 +5,22 @@
 #include <algorithm>
 #include <cmath>
 
-BitArray::BitArray(std::uint32_t p_initial_size_in_bit) {
+BitArray::BitArray(NS::SceneSynchronizerDebugger &p_debugger):
+	debugger(&p_debugger) {
+}
+
+BitArray::BitArray(NS::SceneSynchronizerDebugger &p_debugger, std::uint32_t p_initial_size_in_bit):
+	debugger(&p_debugger) {
 	resize_in_bits(p_initial_size_in_bit);
 }
 
-BitArray::BitArray(const std::vector<std::uint8_t> &p_bytes) :
+BitArray::BitArray(NS::SceneSynchronizerDebugger &p_debugger, const std::vector<std::uint8_t> &p_bytes) :
+	debugger(&p_debugger),
 	bytes(p_bytes) {
+}
+
+void BitArray::operator=(const BitArray &p_other) {
+	debugger = p_other.debugger;
 }
 
 bool BitArray::resize_in_bytes(int p_bytes_count) {

--- a/core/bit_array.cpp
+++ b/core/bit_array.cpp
@@ -21,6 +21,7 @@ BitArray::BitArray(NS::SceneSynchronizerDebugger &p_debugger, const std::vector<
 
 void BitArray::operator=(const BitArray &p_other) {
 	debugger = p_other.debugger;
+	bytes = p_other.bytes;
 }
 
 bool BitArray::resize_in_bytes(int p_bytes_count) {

--- a/core/bit_array.h
+++ b/core/bit_array.h
@@ -12,15 +12,20 @@ class BitArray {
 
 public:
 	BitArray() = default; // Use this with care: Not initializing the debugger will cause a crash
+	BitArray(const BitArray &p_other) = default;
 	BitArray(NS::SceneSynchronizerDebugger &p_debugger);
 	BitArray(NS::SceneSynchronizerDebugger &p_debugger, std::uint32_t p_initial_size_in_bit);
 	BitArray(NS::SceneSynchronizerDebugger &p_debugger, const std::vector<std::uint8_t> &p_bytes);
 
 	void operator=(const BitArray &p_other);
 
+	void set_debugger(NS::SceneSynchronizerDebugger &p_debugger) {
+		debugger = &p_debugger;
+	}
+
 	NS::SceneSynchronizerDebugger &get_debugger() const {
 		return *debugger;
-	};
+	}
 
 	const std::vector<std::uint8_t> &get_bytes() const {
 		return bytes;

--- a/core/bit_array.h
+++ b/core/bit_array.h
@@ -2,13 +2,25 @@
 
 #include <vector>
 
+namespace NS {
+class SceneSynchronizerDebugger;
+}
+
 class BitArray {
+	NS::SceneSynchronizerDebugger *debugger = nullptr;
 	std::vector<std::uint8_t> bytes;
 
 public:
-	BitArray() = default;
-	BitArray(std::uint32_t p_initial_size_in_bit);
-	BitArray(const std::vector<std::uint8_t> &p_bytes);
+	BitArray() = default; // Use this with care: Not initializing the debugger will cause a crash
+	BitArray(NS::SceneSynchronizerDebugger &p_debugger);
+	BitArray(NS::SceneSynchronizerDebugger &p_debugger, std::uint32_t p_initial_size_in_bit);
+	BitArray(NS::SceneSynchronizerDebugger &p_debugger, const std::vector<std::uint8_t> &p_bytes);
+
+	void operator=(const BitArray &p_other);
+
+	NS::SceneSynchronizerDebugger &get_debugger() const {
+		return *debugger;
+	};
 
 	const std::vector<std::uint8_t> &get_bytes() const {
 		return bytes;

--- a/core/data_buffer.cpp
+++ b/core/data_buffer.cpp
@@ -778,8 +778,8 @@ void DataBuffer::add_normalized_vector2(T x, T y, CompressionLevel p_compression
 #ifdef DEBUG_DATA_BUFFER
 	{
 		const T decompressed_angle = (decompress_unit_float<T>(compressed_angle, max_value) * T(M_TAU)) - T(M_PI);
-		const float read_x = std::cos(decompressed_angle) * static_cast<T>(is_not_zero);
-		const float read_y = std::sin(decompressed_angle) * static_cast<T>(is_not_zero);
+		const T read_x = std::cos(decompressed_angle) * static_cast<T>(is_not_zero);
+		const T read_y = std::sin(decompressed_angle) * static_cast<T>(is_not_zero);
 		DEB_WRITE(DATA_TYPE_NORMALIZED_VECTOR2, p_compression_level, "X: " + std::to_string(read_x) + " Y: " + std::to_string(read_y));
 	}
 #endif

--- a/core/data_buffer.cpp
+++ b/core/data_buffer.cpp
@@ -57,13 +57,7 @@
 // TODO improve the allocation mechanism.
 
 NS_NAMESPACE_BEGIN
-DataBuffer::DataBuffer(SceneSynchronizerDebugger &p_debugger) :
-	debugger(&p_debugger),
-	buffer(p_debugger) {
-}
-
-DataBuffer::DataBuffer(SceneSynchronizerDebugger &p_debugger, const DataBuffer &p_other) :
-	debugger(&p_debugger),
+DataBuffer::DataBuffer(const DataBuffer &p_other) :
 	metadata_size(p_other.metadata_size),
 	bit_offset(p_other.bit_offset),
 	bit_size(p_other.bit_size),
@@ -71,8 +65,7 @@ DataBuffer::DataBuffer(SceneSynchronizerDebugger &p_debugger, const DataBuffer &
 	buffer(p_other.buffer) {
 }
 
-DataBuffer::DataBuffer(SceneSynchronizerDebugger &p_debugger, const BitArray &p_buffer) :
-	debugger(&p_debugger),
+DataBuffer::DataBuffer(const BitArray &p_buffer) :
 	bit_size(p_buffer.size_in_bits()),
 	is_reading(true),
 	buffer(p_buffer) {
@@ -92,7 +85,6 @@ bool DataBuffer::operator==(const DataBuffer &p_other) const {
 }
 
 void DataBuffer::copy(const DataBuffer &p_other) {
-	debugger = p_other.debugger;
 	metadata_size = p_other.metadata_size;
 	bit_offset = p_other.bit_offset;
 	bit_size = p_other.bit_size;
@@ -108,8 +100,9 @@ void DataBuffer::copy(const BitArray &p_buffer) {
 	buffer = p_buffer;
 }
 
-void DataBuffer::begin_write(int p_metadata_size) {
+void DataBuffer::begin_write(SceneSynchronizerDebugger &p_debugger, int p_metadata_size) {
 	NS_ASSERT_COND_MSG(p_metadata_size >= 0, "Metadata size can't be negative");
+	buffer.set_debugger(p_debugger);
 	metadata_size = p_metadata_size;
 	bit_size = 0;
 	bit_offset = 0;
@@ -164,7 +157,8 @@ void DataBuffer::skip(int p_bits) {
 	bit_offset += p_bits;
 }
 
-void DataBuffer::begin_read() {
+void DataBuffer::begin_read(SceneSynchronizerDebugger &p_debugger) {
+	buffer.set_debugger(p_debugger);
 	bit_offset = 0;
 	is_reading = true;
 	buffer_failed = false;
@@ -926,6 +920,7 @@ void DataBuffer::read_data_buffer(DataBuffer &r_db) {
 	}
 
 	NS_ASSERT_COND(!r_db.is_reading);
+	r_db.buffer.set_debugger(get_debugger());
 
 	bool using_compression_lvl_2 = false;
 	read(using_compression_lvl_2);

--- a/core/data_buffer.h
+++ b/core/data_buffer.h
@@ -112,7 +112,6 @@ public:
 	};
 
 private:
-	class SceneSynchronizerDebugger *debugger = nullptr;
 	int metadata_size = 0;
 	int bit_offset = 0;
 	int bit_size = 0;
@@ -127,12 +126,11 @@ private:
 
 public:
 	DataBuffer() = default; // Use this with care: Not initialising the debugger will cause a crash.
-	DataBuffer(class SceneSynchronizerDebugger &p_debugger);
-	DataBuffer(class SceneSynchronizerDebugger &p_debugger, const DataBuffer &p_other);
-	DataBuffer(class SceneSynchronizerDebugger &p_debugger, const BitArray &p_buffer);
+	DataBuffer(const DataBuffer &p_other);
+	DataBuffer(const BitArray &p_buffer);
 
 	class SceneSynchronizerDebugger &get_debugger() const {
-		return *debugger;
+		return buffer.get_debugger();
 	}
 
 	//DataBuffer &operator=(DataBuffer &&p_other);
@@ -150,7 +148,7 @@ public:
 	}
 
 	/// Begin write.
-	void begin_write(int p_metadata_size);
+	void begin_write(class SceneSynchronizerDebugger &p_debugger, int p_metadata_size);
 
 	/// Make sure the buffer takes least space possible.
 	void dry();
@@ -176,7 +174,7 @@ public:
 	void skip(int p_bits);
 
 	/// Begin read.
-	void begin_read();
+	void begin_read(class SceneSynchronizerDebugger &p_debugger);
 
 	bool is_buffer_failed() const {
 		return buffer_failed;

--- a/core/data_buffer.h
+++ b/core/data_buffer.h
@@ -112,6 +112,7 @@ public:
 	};
 
 private:
+	class SceneSynchronizerDebugger *debugger = nullptr;
 	int metadata_size = 0;
 	int bit_offset = 0;
 	int bit_size = 0;
@@ -125,9 +126,14 @@ private:
 #endif
 
 public:
-	DataBuffer() = default;
-	DataBuffer(const DataBuffer &p_other);
-	DataBuffer(const BitArray &p_buffer);
+	DataBuffer() = default; // Use this with care: Not initialising the debugger will cause a crash.
+	DataBuffer(class SceneSynchronizerDebugger &p_debugger);
+	DataBuffer(class SceneSynchronizerDebugger &p_debugger, const DataBuffer &p_other);
+	DataBuffer(class SceneSynchronizerDebugger &p_debugger, const BitArray &p_buffer);
+
+	class SceneSynchronizerDebugger &get_debugger() const {
+		return *debugger;
+	}
 
 	//DataBuffer &operator=(DataBuffer &&p_other);
 	bool operator==(const DataBuffer &p_other) const;
@@ -379,7 +385,7 @@ public:
 	int read_normalized_vector3_size(CompressionLevel p_compression);
 	int read_buffer_size();
 
-	static int get_bit_taken(DataType p_data_type, CompressionLevel p_compression);
+	int get_bit_taken(DataType p_data_type, CompressionLevel p_compression) const;
 	template <typename T>
 	static T get_real_epsilon(DataType p_data_type, CompressionLevel p_compression);
 

--- a/core/ensure.cpp
+++ b/core/ensure.cpp
@@ -3,6 +3,7 @@
 #include "../scene_synchronizer.h"
 
 void _ns_print_code_message(
+		NS::SceneSynchronizerDebugger &p_debugger,
 		const char *p_function,
 		const char *p_file,
 		int p_line,
@@ -10,6 +11,24 @@ void _ns_print_code_message(
 		const std::string &p_message,
 		NS::PrintMessageType p_type) {
 	NS::SceneSynchronizerBase::print_code_message(
+			&p_debugger,
+			p_function,
+			p_file,
+			p_line,
+			p_error,
+			p_message,
+			p_type);
+}
+
+void _ns_print_code_message(
+		const char *p_function,
+		const char *p_file,
+		int p_line,
+		const std::string &p_error,
+		const std::string &p_message,
+		NS::PrintMessageType p_type) {
+	NS::SceneSynchronizerBase::print_code_message(
+			nullptr,
 			p_function,
 			p_file,
 			p_line,

--- a/core/ensure.h
+++ b/core/ensure.h
@@ -29,6 +29,19 @@
 #define _MKSTR(m_x) _STR(m_x)
 #endif
 
+namespace NS {
+class SceneSynchronizerDebugger;
+};
+
+void _ns_print_code_message(
+		NS::SceneSynchronizerDebugger &p_debugger,
+		const char *p_function,
+		const char *p_file,
+		int p_line,
+		const std::string &p_error,
+		const std::string &p_message,
+		NS::PrintMessageType p_type);
+
 void _ns_print_code_message(
 		const char *p_function,
 		const char *p_file,
@@ -44,7 +57,7 @@ void _ns_print_flush_stdout();
 #define NS_ENSURE(m_cond)                                                                                                                         \
 	if make_likely (m_cond) {                                                                                                                  \
 	} else {                                                                                                                                   \
-		_ns_print_code_message(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is false.", "", NS::PrintMessageType::ERROR); \
+		_ns_print_code_message(get_debugger(), FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is false.", "", NS::PrintMessageType::ERROR); \
 		return;                                                                                                                                \
 	}
 
@@ -53,7 +66,7 @@ void _ns_print_flush_stdout();
 #define NS_ENSURE_MSG(m_cond, m_msg)                                                                                                                                            \
 	if make_likely (m_cond) {                                                                                                                                                \
 	} else {                                                                                                                                                                 \
-		_ns_print_code_message(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is false. Returning: " _STR(m_retval), m_msg, NS::PrintMessageType::ERROR); \
+		_ns_print_code_message(get_debugger(), FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is false. Returning: " _STR(m_retval), m_msg, NS::PrintMessageType::ERROR); \
 		return;                                                                                                                                                              \
 	}
 
@@ -62,7 +75,7 @@ void _ns_print_flush_stdout();
 #define NS_ENSURE_V(m_cond, m_retval)                                                                                                                                        \
 	if make_likely (m_cond) {                                                                                                                                             \
 	} else {                                                                                                                                                              \
-		_ns_print_code_message(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is false. Returning: " _STR(m_retval), "", NS::PrintMessageType::ERROR); \
+		_ns_print_code_message(get_debugger(), FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is false. Returning: " _STR(m_retval), "", NS::PrintMessageType::ERROR); \
 		return m_retval;                                                                                                                                                  \
 	}
 
@@ -71,28 +84,28 @@ void _ns_print_flush_stdout();
 #define NS_ENSURE_V_MSG(m_cond, m_retval, m_msg)                                                                                                                                \
 	if make_likely (m_cond) {                                                                                                                                                \
 	} else {                                                                                                                                                                 \
-		_ns_print_code_message(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is false. Returning: " _STR(m_retval), m_msg, NS::PrintMessageType::ERROR); \
+		_ns_print_code_message(get_debugger(), FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is false. Returning: " _STR(m_retval), m_msg, NS::PrintMessageType::ERROR); \
 		return m_retval;                                                                                                                                                     \
 	}
 
 /// Ensures no entry
 #define NS_ENSURE_NO_ENTRY()                                                                                         \
-	_ns_print_code_message(FUNCTION_STR, __FILE__, __LINE__, "No entry triggered", "", NS::PrintMessageType::ERROR); \
-	return;                                                                                                                                
+	_ns_print_code_message(get_debugger(), FUNCTION_STR, __FILE__, __LINE__, "No entry triggered", "", NS::PrintMessageType::ERROR); \
+	return;
 
 /// Ensures no entry with message
 #define NS_ENSURE_NO_ENTRY_MSG(m_msg)                                                                                                     \
-	_ns_print_code_message(FUNCTION_STR, __FILE__, __LINE__, "No entry. Returning: " _STR(m_retval), m_msg, NS::PrintMessageType::ERROR); \
+	_ns_print_code_message(get_debugger(), FUNCTION_STR, __FILE__, __LINE__, "No entry. Returning: " _STR(m_retval), m_msg, NS::PrintMessageType::ERROR); \
 	return;
 
 /// Ensures no entry with return value.
 #define NS_ENSURE_NO_ENTRY_V(m_retval)                                                                                                 \
-	_ns_print_code_message(FUNCTION_STR, __FILE__, __LINE__, "No entry. Returning: " _STR(m_retval), "", NS::PrintMessageType::ERROR); \
+	_ns_print_code_message(get_debugger(), FUNCTION_STR, __FILE__, __LINE__, "No entry. Returning: " _STR(m_retval), "", NS::PrintMessageType::ERROR); \
 	return m_retval;
 
 /// Ensures no entry with return value and with message.
 #define NS_ENSURE_NO_ENTRY_V_MSG(m_retval, m_msg)                                                                                        \
-	_ns_print_code_message(FUNCTION_STR, __FILE__, __LINE__, "No entry. Returning: " _STR(m_retval), m_msg, NS::PrintMessageType::ERROR); \
+	_ns_print_code_message(get_debugger(), FUNCTION_STR, __FILE__, __LINE__, "No entry. Returning: " _STR(m_retval), m_msg, NS::PrintMessageType::ERROR); \
 	return m_retval;
 
 /// Ensures `m_cond` is true.
@@ -100,7 +113,7 @@ void _ns_print_flush_stdout();
 #define NS_ENSURE_CONTINUE(m_cond)                                                                                                                \
 	if make_likely (m_cond) {                                                                                                                  \
 	} else {                                                                                                                                   \
-		_ns_print_code_message(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is false.", "", NS::PrintMessageType::ERROR); \
+		_ns_print_code_message(get_debugger(), FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is false.", "", NS::PrintMessageType::ERROR); \
 		continue;                                                                                                                              \
 	}
 
@@ -109,7 +122,7 @@ void _ns_print_flush_stdout();
 #define NS_ENSURE_CONTINUE_MSG(m_cond, m_msg)                                                                                                        \
 	if make_likely (m_cond) {                                                                                                                     \
 	} else {                                                                                                                                      \
-		_ns_print_code_message(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is false.", m_msg, NS::PrintMessageType::ERROR); \
+		_ns_print_code_message(get_debugger(), FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is false.", m_msg, NS::PrintMessageType::ERROR); \
 		continue;                                                                                                                                 \
 	}
 

--- a/core/net_utilities.cpp
+++ b/core/net_utilities.cpp
@@ -6,6 +6,10 @@
 #include "peer_networked_controller.h"
 #include "scene_synchronizer_debugger.h"
 
+NS::SceneSynchronizerDebugger &NS::SyncGroup::get_debugger() const {
+	return scene_sync->get_debugger();
+}
+
 void NS::SyncGroup::advance_timer_state_notifier(
 		const float p_delta,
 		const float p_frame_confirmation_timespan,
@@ -384,7 +388,7 @@ float NS::SyncGroup::get_trickled_update_rate(const NS::ObjectData *p_object_dat
 			return trickled_sync_objects[i].update_rate;
 		}
 	}
-	SceneSynchronizerDebugger::singleton()->print(ERROR, "NodeData " + p_object_data->get_object_name() + " not found into `trickled_sync_objects`.");
+	get_debugger().print(ERROR, "NodeData " + p_object_data->get_object_name() + " not found into `trickled_sync_objects`.");
 	return 0.0;
 }
 

--- a/core/net_utilities.h
+++ b/core/net_utilities.h
@@ -3,7 +3,6 @@
 #include "core.h"
 #include "processor.h"
 #include "var_data.h"
-#include "NetworkSynchronizer/scene_synchronizer.h"
 
 #include <algorithm>
 #include <map>
@@ -382,7 +381,7 @@ public:
 	uint64_t user_data = 0;
 
 public:
-	SceneSynchronizerDebugger &get_debugger() const;
+	class SceneSynchronizerDebugger &get_debugger() const;
 
 	void advance_timer_state_notifier(
 			const float p_delta,

--- a/core/net_utilities.h
+++ b/core/net_utilities.h
@@ -3,6 +3,8 @@
 #include "core.h"
 #include "processor.h"
 #include "var_data.h"
+#include "NetworkSynchronizer/scene_synchronizer.h"
+
 #include <algorithm>
 #include <map>
 
@@ -380,6 +382,8 @@ public:
 	uint64_t user_data = 0;
 
 public:
+	SceneSynchronizerDebugger &get_debugger() const;
+
 	void advance_timer_state_notifier(
 			const float p_delta,
 			const float p_frame_confirmation_timespan,

--- a/core/network_interface.h
+++ b/core/network_interface.h
@@ -10,19 +10,29 @@
 #include <vector>
 
 NS_NAMESPACE_BEGIN
-
 template <typename... ARGs>
 class RpcHandle {
 	friend class NetworkInterface;
 
+	class SceneSynchronizerDebugger *debugger = nullptr;
 	std::uint8_t index = std::numeric_limits<std::uint8_t>::max();
-	RpcHandle(std::uint8_t p_index) :
-			index(p_index) {}
+
+	RpcHandle(SceneSynchronizerDebugger &p_debugger, std::uint8_t p_index) :
+		debugger(&p_debugger),
+		index(p_index) {
+	}
 
 public:
 	RpcHandle() = default;
 
-	std::uint8_t get_index() const { return index; }
+	SceneSynchronizerDebugger &get_debugger() const {
+		return *debugger;
+	}
+
+	std::uint8_t get_index() const {
+		return index;
+	}
+
 	void reset() {
 		index = std::numeric_limits<std::uint8_t>::max();
 	}
@@ -44,11 +54,20 @@ public:
 protected:
 	std::vector<RPCInfo> rpcs_info;
 	int rpc_last_sender = 0;
+	SceneSynchronizerDebugger *debugger = nullptr;
 
 public:
 	virtual ~NetworkInterface() = default;
 
 public: // ----------------------------------------------------------- Interface
+	void __set_debugger(SceneSynchronizerDebugger &p_debugger) {
+		debugger = &p_debugger;
+	}
+
+	class SceneSynchronizerDebugger &get_debugger() const {
+		return *debugger;
+	}
+
 	virtual void reset() {
 		rpcs_info.clear();
 		rpc_last_sender = 0;
@@ -97,12 +116,12 @@ public: // ---------------------------------------------------------------- APIs
 		// responsible to execute the user rpc function.
 		std::function<void(DataBuffer &)> func =
 				[p_rpc_func](DataBuffer &p_db) {
-					internal_call_rpc(p_rpc_func, p_db);
-				};
+			internal_call_rpc(p_rpc_func, p_db);
+		};
 
 		const std::uint8_t rpc_index = std::uint8_t(rpcs_info.size());
 		rpcs_info.push_back({ p_reliable, p_call_local, func });
-		return RpcHandle<ARGS...>(rpc_index);
+		return RpcHandle<ARGS...>(get_debugger(), rpc_index);
 	}
 
 	/// Calls an rpc.
@@ -162,7 +181,7 @@ void RpcHandle<ARGs...>::rpc(NetworkInterface &p_interface, int p_peer_id, ARGs.
 	NS_ENSURE(p_interface.rpcs_info.size() > index);
 	NS_ASSERT_COND_MSG(p_interface.get_local_peer_id() != p_peer_id, "Sending an rpc to self is not allowed.");
 
-	DataBuffer db;
+	DataBuffer db(get_debugger());
 	db.begin_write(0);
 
 	// Add the rpc id.

--- a/core/network_interface.h
+++ b/core/network_interface.h
@@ -5,6 +5,7 @@
 #include "ensure.h"
 #include "network_codec.h"
 #include "net_utilities.h"
+#include "scene_synchronizer_debugger.h"
 #include "peer_data.h"
 #include <functional>
 #include <vector>
@@ -54,18 +55,14 @@ public:
 protected:
 	std::vector<RPCInfo> rpcs_info;
 	int rpc_last_sender = 0;
-	SceneSynchronizerDebugger *debugger = nullptr;
+	mutable SceneSynchronizerDebugger debugger;
 
 public:
 	virtual ~NetworkInterface() = default;
 
 public: // ----------------------------------------------------------- Interface
-	void __set_debugger(SceneSynchronizerDebugger &p_debugger) {
-		debugger = &p_debugger;
-	}
-
-	class SceneSynchronizerDebugger &get_debugger() const {
-		return *debugger;
+	SceneSynchronizerDebugger &get_debugger() const {
+		return debugger;
 	}
 
 	virtual void reset() {
@@ -135,7 +132,7 @@ public: // ---------------------------------------------------------------- APIs
 	/// This function must be called by the `Network` manager when this unit receives an rpc.
 	void rpc_receive(int p_sender_peer, DataBuffer &p_db) {
 		rpc_last_sender = p_sender_peer;
-		p_db.begin_read();
+		p_db.begin_read(get_debugger());
 		std::uint8_t rpc_id;
 		p_db.read(rpc_id);
 		NS_ENSURE_MSG(rpc_id < rpcs_info.size(), "The received rpc contains a broken RPC ID: `" + std::to_string(rpc_id) + "`, the `rpcs_info` size is `" + std::to_string(rpcs_info.size()) + "`.");
@@ -182,7 +179,7 @@ void RpcHandle<ARGs...>::rpc(NetworkInterface &p_interface, int p_peer_id, ARGs.
 	NS_ASSERT_COND_MSG(p_interface.get_local_peer_id() != p_peer_id, "Sending an rpc to self is not allowed.");
 
 	DataBuffer db(get_debugger());
-	db.begin_write(0);
+	db.begin_write(get_debugger(), 0);
 
 	// Add the rpc id.
 	db.add(index);
@@ -191,13 +188,13 @@ void RpcHandle<ARGs...>::rpc(NetworkInterface &p_interface, int p_peer_id, ARGs.
 	encode_variables<0>(db, p_args...);
 
 	db.dry();
-	db.begin_read();
+	db.begin_read(get_debugger());
 
 	if (p_interface.rpcs_info[index].call_local) {
 		p_interface.rpc_receive(p_interface.get_local_peer_id(), db);
 	}
 
-	db.begin_read();
+	db.begin_read(get_debugger());
 	p_interface.rpc_send(p_peer_id, p_interface.rpcs_info[index].is_reliable, std::move(db));
 }
 

--- a/core/object_data_storage.cpp
+++ b/core/object_data_storage.cpp
@@ -89,7 +89,7 @@ void ObjectDataStorage::object_set_net_id(ObjectData &p_object_data, ObjectNetId
 
 	if (objects_data_organized_by_netid.size() > p_new_id.id) {
 		if (objects_data_organized_by_netid[p_new_id.id] && objects_data_organized_by_netid[p_new_id.id] != (&p_object_data)) {
-			SceneSynchronizerDebugger::singleton()->print(ERROR, "[NET] The object `" + p_object_data.object_name + "` was associated with to a new NetId that was used by `" + objects_data_organized_by_netid[p_new_id.id]->object_name + "`. THIS IS NOT SUPPOSED TO HAPPEN.");
+			get_debugger().print(ERROR, "[NET] The object `" + p_object_data.object_name + "` was associated with to a new NetId that was used by `" + objects_data_organized_by_netid[p_new_id.id]->object_name + "`. THIS IS NOT SUPPOSED TO HAPPEN.");
 		}
 	} else {
 		// Expand the array

--- a/core/object_data_storage.cpp
+++ b/core/object_data_storage.cpp
@@ -22,6 +22,10 @@ ObjectDataStorage::~ObjectDataStorage() {
 	objects_data_controlled_by_peers.clear();
 }
 
+SceneSynchronizerDebugger &ObjectDataStorage::get_debugger() const {
+	return sync.get_debugger();
+}
+
 ObjectData *ObjectDataStorage::allocate_object_data() {
 	ObjectData *od = new ObjectData(*this);
 

--- a/core/object_data_storage.h
+++ b/core/object_data_storage.h
@@ -24,6 +24,8 @@ public:
 	ObjectDataStorage(class SceneSynchronizerBase &p_sync);
 	~ObjectDataStorage();
 
+	class SceneSynchronizerDebugger &get_debugger() const;
+
 	ObjectData *allocate_object_data();
 	void deallocate_object_data(ObjectData &p_object_data);
 

--- a/core/peer_data.cpp
+++ b/core/peer_data.cpp
@@ -14,6 +14,6 @@ void NS::PeerData::set_out_packet_loss_percentage(float p_packet_loss) {
 	out_packet_loss_percentage = std::clamp(p_packet_loss, 0.0f, 1.0f);
 }
 
-void NS::PeerData::make_controller() {
-	controller = std::make_unique<NS::PeerNetworkedController>();
+void NS::PeerData::make_controller(SceneSynchronizerBase &p_scene_synchronizer) {
+	controller = std::make_unique<NS::PeerNetworkedController>(p_scene_synchronizer);
 }

--- a/core/peer_data.h
+++ b/core/peer_data.h
@@ -1,11 +1,9 @@
-
 #pragma once
 
 #include "core.h"
 #include "peer_networked_controller.h"
 
 NS_NAMESPACE_BEGIN
-
 // These data are used by the server and are never synchronized.
 struct PeerAuthorityData {
 	// Used to know if the peer is enabled.
@@ -42,11 +40,14 @@ public:
 	// stop working and didn't have the time to figure it out.
 	// TODO consider to fix this --^
 	PeerData() = default;
+
 	PeerData(const PeerData &other) :
-			authority_data(other.authority_data),
-			compressed_latency(other.compressed_latency),
-			out_packet_loss_percentage(other.out_packet_loss_percentage),
-			latency_jitter_ms(other.latency_jitter_ms) {}
+		authority_data(other.authority_data),
+		compressed_latency(other.compressed_latency),
+		out_packet_loss_percentage(other.out_packet_loss_percentage),
+		latency_jitter_ms(other.latency_jitter_ms) {
+	}
+
 	PeerData &operator=(const PeerData &other) noexcept {
 		authority_data = other.authority_data;
 		compressed_latency = other.compressed_latency;
@@ -62,19 +63,34 @@ public:
 	// In ms
 	float get_latency() const;
 
-	void set_compressed_latency(std::uint8_t p_compressed_latency) { compressed_latency = p_compressed_latency; }
-	std::uint8_t get_compressed_latency() const { return compressed_latency; }
+	void set_compressed_latency(std::uint8_t p_compressed_latency) {
+		compressed_latency = p_compressed_latency;
+	}
+
+	std::uint8_t get_compressed_latency() const {
+		return compressed_latency;
+	}
 
 	void set_out_packet_loss_percentage(float p_packet_loss);
-	float get_out_packet_loss_percentage() const { return out_packet_loss_percentage; }
 
-	void set_latency_jitter_ms(float p_jitter_ms) { latency_jitter_ms = p_jitter_ms; }
-	float get_latency_jitter_ms() const { return latency_jitter_ms; }
+	float get_out_packet_loss_percentage() const {
+		return out_packet_loss_percentage;
+	}
 
-	void make_controller();
+	void set_latency_jitter_ms(float p_jitter_ms) {
+		latency_jitter_ms = p_jitter_ms;
+	}
+
+	float get_latency_jitter_ms() const {
+		return latency_jitter_ms;
+	}
+
+	void make_controller(SceneSynchronizerBase &p_scene_synchronizer);
+
 	PeerNetworkedController *get_controller() {
 		return controller.get();
 	}
+
 	const PeerNetworkedController *get_controller() const {
 		return controller.get();
 	}

--- a/core/peer_networked_controller.h
+++ b/core/peer_networked_controller.h
@@ -4,6 +4,7 @@
 #include "data_buffer.h"
 #include "processor.h"
 #include "snapshot.h"
+
 #include <deque>
 
 NS_NAMESPACE_BEGIN
@@ -77,10 +78,13 @@ public: // -------------------------------------------------------------- Events
 	Processor<FrameIndex> event_input_missed;
 
 public:
-	PeerNetworkedController();
+	PeerNetworkedController(SceneSynchronizerBase &p_scene_synchronizer);
 	~PeerNetworkedController();
 
 public: // ---------------------------------------------------------------- APIs
+	class SceneSynchronizerDebugger &get_debugger();
+	const class SceneSynchronizerDebugger &get_debugger() const;
+
 	void notify_controllable_objects_changed();
 
 	const std::vector<ObjectData *> &get_sorted_controllable_objects();
@@ -128,7 +132,7 @@ public: // -------------------------------------------------------------- Events
 public:
 	void set_inputs_buffer(const BitArray &p_new_buffer, uint32_t p_metadata_size_in_bit, uint32_t p_size_in_bit);
 
-	void setup_synchronizer(NS::SceneSynchronizerBase &p_synchronizer, int p_peer);
+	void setup_synchronizer(int p_peer);
 	void remove_synchronizer();
 
 	int get_authority_peer() const {

--- a/core/peer_networked_controller.h
+++ b/core/peer_networked_controller.h
@@ -82,8 +82,7 @@ public:
 	~PeerNetworkedController();
 
 public: // ---------------------------------------------------------------- APIs
-	class SceneSynchronizerDebugger &get_debugger();
-	const class SceneSynchronizerDebugger &get_debugger() const;
+	class SceneSynchronizerDebugger &get_debugger() const;
 
 	void notify_controllable_objects_changed();
 
@@ -174,6 +173,12 @@ struct FrameInput {
 	std::uint16_t buffer_size_bit = 0;
 	FrameIndex similarity = FrameIndex::NONE;
 
+	FrameInput() = default;
+
+	FrameInput(SceneSynchronizerDebugger &p_debugger):
+		inputs_buffer(p_debugger) {
+	}
+
 	bool operator==(const FrameInput &p_other) const {
 		return p_other.id == id;
 	}
@@ -187,6 +192,10 @@ struct Controller {
 	}
 
 	virtual ~Controller() = default;
+
+	SceneSynchronizerDebugger &get_debugger() const {
+		return peer_controller->get_debugger();
+	}
 
 	virtual void ready() {
 	}

--- a/core/scene_synchronizer_debugger.cpp
+++ b/core/scene_synchronizer_debugger.cpp
@@ -8,41 +8,30 @@
 #endif
 
 #include "data_buffer.h"
-#include "net_utilities.h"
 #include "scene_synchronizer_debugger_json_storage.h"
 
 #endif
 
 #include "../scene_synchronizer.h"
 
+NS_NAMESPACE_BEGIN
 SceneSynchronizerDebugger *SceneSynchronizerDebugger::the_singleton = nullptr;
 
-SceneSynchronizerDebugger *SceneSynchronizerDebugger::singleton() {
-	return the_singleton;
-}
-
-void SceneSynchronizerDebugger::__set_singleton(SceneSynchronizerDebugger *p_singleton) {
-	the_singleton = p_singleton;
-}
-
 SceneSynchronizerDebugger::SceneSynchronizerDebugger() {
-	if (the_singleton == nullptr) {
-		the_singleton = this;
-	}
 #ifdef NS_DEBUG_ENABLED
 	frame_dump_storage = new SceneSynchronizerDebuggerJsonStorage;
 #endif
 }
 
 SceneSynchronizerDebugger::~SceneSynchronizerDebugger() {
-	if (the_singleton == this) {
-		the_singleton = nullptr;
-	}
-
 #ifdef NS_DEBUG_ENABLED
 	delete frame_dump_storage;
 	frame_dump_storage = nullptr;
 #endif
+}
+
+SceneSynchronizerDebugger &SceneSynchronizerDebugger::get_debugger() const {
+	return *const_cast<SceneSynchronizerDebugger *>(this);
 }
 
 void SceneSynchronizerDebugger::set_file_system(NS::FileSystem *p_file_system) {
@@ -97,7 +86,7 @@ void SceneSynchronizerDebugger::prepare_dumping(int p_peer) {
 		return;
 	}
 
-	NS_ENSURE_MSG(!file_system, "Please set the FileSystem using the function set_file_system().");
+	NS_ENSURE_MSG(file_system, "Please set the FileSystem using the function set_file_system().");
 
 	// Prepare the dir.
 	{
@@ -124,7 +113,7 @@ void SceneSynchronizerDebugger::prepare_dumping(int p_peer) {
 void SceneSynchronizerDebugger::setup_debugger_python_ui() {
 #ifdef UI_DEBUGGER_ENABLED
 #ifdef NS_DEBUG_ENABLED
-	NS_ENSURE_MSG(!file_system, "Please set the FileSystem using the function set_file_system().");
+	NS_ENSURE_MSG(file_system, "Please set the FileSystem using the function set_file_system().");
 
 	// Verify if file exists.
 	const std::string path = main_dump_directory_path + "/debugger.py";
@@ -151,7 +140,7 @@ void SceneSynchronizerDebugger::write_dump(int p_peer, uint32_t p_frame_index) {
 		return;
 	}
 
-	NS_ENSURE_MSG(!file_system, "Please set the FileSystem using the function set_file_system().");
+	NS_ENSURE_MSG(file_system, "Please set the FileSystem using the function set_file_system().");
 
 	std::string file_path = "";
 	{
@@ -207,94 +196,6 @@ void SceneSynchronizerDebugger::start_new_frame() {
 }
 
 #ifdef NS_DEBUG_ENABLED
-/*
-std::string type_to_string(Variant::Type p_type) {
-	switch (p_type) {
-		case Variant::NIL:
-			return "NIL";
-		case Variant::BOOL:
-			return "BOOL";
-		case Variant::INT:
-			return "INT";
-		case Variant::FLOAT:
-			return "FLOAT";
-		case Variant::STRING:
-			return "STRING";
-		case Variant::VECTOR2:
-			return "VECTOR2";
-		case Variant::VECTOR2I:
-			return "VECTOR2I";
-		case Variant::RECT2:
-			return "RECT2";
-		case Variant::RECT2I:
-			return "RECT2I";
-		case Variant::VECTOR3:
-			return "VECTOR3";
-		case Variant::VECTOR3I:
-			return "VECTOR3I";
-		case Variant::TRANSFORM2D:
-			return "TRANSFORM2D";
-		case Variant::VECTOR4:
-			return "VECTOR4";
-		case Variant::VECTOR4I:
-			return "VECTOR4I";
-		case Variant::PLANE:
-			return "PLANE";
-		case Variant::QUATERNION:
-			return "QUATERNION";
-		case Variant::AABB:
-			return "AABB";
-		case Variant::BASIS:
-			return "BASIS";
-		case Variant::TRANSFORM3D:
-			return "TRANSFORM3D";
-		case Variant::PROJECTION:
-			return "PROJECTION";
-		case Variant::COLOR:
-			return "COLOR";
-		case Variant::STRING_NAME:
-			return "STRING_NAME";
-		case Variant::NODE_PATH:
-			return "NODE_PATH";
-		case Variant::RID:
-			return "RID";
-		case Variant::OBJECT:
-			return "OBJECT";
-		case Variant::CALLABLE:
-			return "CALLABLE";
-		case Variant::SIGNAL:
-			return "SIGNAL";
-		case Variant::DICTIONARY:
-			return "DICTIONARY";
-		case Variant::ARRAY:
-			return "ARRAY";
-		case Variant::PACKED_BYTE_ARRAY:
-			return "PACKED_BYTE_ARRAY";
-		case Variant::PACKED_INT32_ARRAY:
-			return "PACKED_INT32_ARRAY";
-		case Variant::PACKED_INT64_ARRAY:
-			return "PACKED_INT64_ARRAY";
-		case Variant::PACKED_FLOAT32_ARRAY:
-			return "PACKED_FLOAT32_ARRAY";
-		case Variant::PACKED_FLOAT64_ARRAY:
-			return "PACKED_FLOAT64_ARRAY";
-		case Variant::PACKED_STRING_ARRAY:
-			return "PACKED_STRING_ARRAY";
-		case Variant::PACKED_VECTOR2_ARRAY:
-			return "PACKED_VECTOR2_ARRAY";
-		case Variant::PACKED_VECTOR3_ARRAY:
-			return "PACKED_VECTOR3_ARRAY";
-		case Variant::PACKED_COLOR_ARRAY:
-			return "PACKED_COLOR_ARRAY";
-		case Variant::PACKED_VECTOR4_ARRAY:
-			return "PACKED_VECTOR4_ARRAY";
-		case Variant::VARIANT_MAX:
-			return "VARIANT_MAX";
-	}
-	return "";
-}
-*/
-
 std::string data_type_to_string(uint32_t p_type) {
 	switch (p_type) {
 		case NS::DataBuffer::DATA_TYPE_BOOL:
@@ -527,3 +428,5 @@ void SceneSynchronizerDebugger::__add_message(const std::string &p_message, cons
 	log_counter += 1;
 #endif
 }
+
+NS_NAMESPACE_END

--- a/core/scene_synchronizer_debugger.h
+++ b/core/scene_synchronizer_debugger.h
@@ -25,8 +25,6 @@ public:
 };
 
 class SceneSynchronizerDebugger {
-	static SceneSynchronizerDebugger *the_singleton;
-
 public:
 	enum DataBufferDumpMode {
 		NONE,
@@ -47,7 +45,7 @@ private:
 	bool dump_enabled = false;
 	bool setup_done = false;
 
-	NS::FileSystem *file_system = nullptr;
+	FileSystem *file_system = nullptr;
 
 	uint32_t log_counter = 0;
 	std::string main_dump_directory_path;
@@ -70,9 +68,9 @@ public:
 
 	SceneSynchronizerDebugger &get_debugger() const;
 
-	void set_file_system(NS::FileSystem *p_file_system);
+	void set_file_system(FileSystem *p_file_system);
 
-	NS::FileSystem *get_file_system() const {
+	FileSystem *get_file_system() const {
 #ifdef NS_DEBUG_ENABLED
 		return file_system;
 #else
@@ -80,8 +78,8 @@ public:
 #endif
 	}
 
-	void set_log_level(NS::PrintMessageType p_log_level);
-	NS::PrintMessageType get_log_level() const;
+	void set_log_level(PrintMessageType p_log_level);
+	PrintMessageType get_log_level() const;
 
 	void set_dump_enabled(bool p_dump_enabled);
 	bool get_dump_enabled() const;
@@ -96,8 +94,8 @@ public:
 	void write_dump(int p_peer, uint32_t p_frame_index);
 	void start_new_frame();
 
-	void scene_sync_process_start(const NS::SceneSynchronizerBase *p_scene_sync);
-	void scene_sync_process_end(const NS::SceneSynchronizerBase *p_scene_sync);
+	void scene_sync_process_start(const SceneSynchronizerBase *p_scene_sync);
+	void scene_sync_process_end(const SceneSynchronizerBase *p_scene_sync);
 
 	void databuffer_operation_begin_record(int p_peer, DataBufferDumpMode p_mode);
 	void databuffer_operation_end_record();
@@ -108,7 +106,7 @@ public:
 	void notify_are_inputs_different_result(int p_peer, uint32_t p_other_frame_index, bool p_is_similar);
 
 	void print(
-			NS::PrintMessageType p_level,
+			PrintMessageType p_level,
 			const std::string &p_message,
 			const std::string &p_object_name = "GLOBAL",
 			bool p_force_print_to_log = false);

--- a/core/scene_synchronizer_debugger.h
+++ b/core/scene_synchronizer_debugger.h
@@ -94,8 +94,8 @@ public:
 	void write_dump(int p_peer, uint32_t p_frame_index);
 	void start_new_frame();
 
-	void scene_sync_process_start(const SceneSynchronizerBase *p_scene_sync);
-	void scene_sync_process_end(const SceneSynchronizerBase *p_scene_sync);
+	void scene_sync_process_start(SceneSynchronizerBase &p_scene_sync);
+	void scene_sync_process_end(SceneSynchronizerBase &p_scene_sync);
 
 	void databuffer_operation_begin_record(int p_peer, DataBufferDumpMode p_mode);
 	void databuffer_operation_end_record();

--- a/core/scene_synchronizer_debugger.h
+++ b/core/scene_synchronizer_debugger.h
@@ -20,8 +20,6 @@ public:
 	virtual bool file_exists(const std::string &p_path) const = 0;
 };
 
-NS_NAMESPACE_END
-
 class SceneSynchronizerDebugger {
 	static SceneSynchronizerDebugger *the_singleton;
 
@@ -38,13 +36,8 @@ public:
 		CLIENT_DESYNC_DETECTED_SOFT = 1 << 1,
 	};
 
-public:
-	static SceneSynchronizerDebugger *singleton();
-	// USE THIS WITH CARE <3
-	static void __set_singleton(SceneSynchronizerDebugger *p_singleton);
-
 private:
-	NS::PrintMessageType log_level = NS::PrintMessageType::ERROR;
+	PrintMessageType log_level = NS::PrintMessageType::ERROR;
 
 #ifdef NS_DEBUG_ENABLED
 	bool dump_enabled = false;
@@ -61,7 +54,7 @@ private:
 	//         inside the CPP and avoid clutter the includes, since that header includes many non wanted includes.
 	struct SceneSynchronizerDebuggerJsonStorage *frame_dump_storage = nullptr;
 
-	// A really small description about what happens on this frame.
+	// A small description about what happens on this frame.
 	FrameEvent frame_dump__frame_events = FrameEvent::EMPTY;
 
 	DataBufferDumpMode frame_dump_data_buffer_dump_mode = NONE;
@@ -70,6 +63,8 @@ private:
 public:
 	SceneSynchronizerDebugger();
 	~SceneSynchronizerDebugger();
+
+	SceneSynchronizerDebugger &get_debugger() const;
 
 	void set_file_system(NS::FileSystem *p_file_system);
 
@@ -118,3 +113,5 @@ public:
 
 	void __add_message(const std::string &p_message, const std::string &p_object_name);
 };
+
+NS_NAMESPACE_END

--- a/core/scene_synchronizer_debugger.h
+++ b/core/scene_synchronizer_debugger.h
@@ -15,7 +15,11 @@ public:
 	virtual std::string get_date() const = 0;
 	virtual std::string get_time() const = 0;
 	virtual bool make_dir_recursive(const std::string &p_dir_path, bool p_erase_content) const = 0;
-	virtual bool store_file_string(const std::string &p_path, const std::string &p_string_file) const = 0;
+
+	virtual bool store_file_string(const std::string &p_path, const std::string &p_string_file) const {
+		return store_file_buffer(p_path, reinterpret_cast<const std::uint8_t *>(p_string_file.c_str()), p_string_file.length());
+	}
+
 	virtual bool store_file_buffer(const std::string &p_path, const std::uint8_t *p_src, uint64_t p_length) const = 0;
 	virtual bool file_exists(const std::string &p_path) const = 0;
 };

--- a/core/scene_synchronizer_debugger_json_storage.h
+++ b/core/scene_synchronizer_debugger_json_storage.h
@@ -2,6 +2,7 @@
 
 #include "json.hpp"
 
+namespace NS {
 struct SceneSynchronizerDebuggerJsonStorage {
 #ifdef NS_DEBUG_ENABLED
 	nlohmann::json::object_t frame_dump__begin_state;
@@ -30,4 +31,5 @@ struct SceneSynchronizerDebuggerJsonStorage {
 	bool frame_dump__has_warnings = false;
 	bool frame_dump__has_errors = false;
 #endif
+};
 };

--- a/debugger_ui/cpplize_debugger.py
+++ b/debugger_ui/cpplize_debugger.py
@@ -1,9 +1,10 @@
 from os import listdir
 from os.path import isfile, join, isdir, exists
+import sys
 
-def create_debugger_header():
+def create_debugger_header(source_path):
     
-    f = open("core/__generated__debugger_ui.h", "w", encoding="utf-8")
+    f = open(source_path + "/core/__generated__debugger_ui.h", "w", encoding="utf-8")
     f.write("#pragma once\n")
     f.write("\n")
     f.write("/// This is a generated file by `cpplize_debugger.py`, executed by `SCsub`.\n")
@@ -19,7 +20,7 @@ def create_debugger_header():
     f.write("static const char __debugger_ui_code[] = R\"TheCodeRKS(")
 
     size = 0
-    with open('./debugger_ui/debugger.py', encoding="utf-8") as deb_f:
+    with open(source_path + '/debugger_ui/debugger.py', encoding="utf-8") as deb_f:
         for l in deb_f.readlines():
             l_utf8 = l.encode('utf-8')
             size += len(l_utf8)
@@ -28,3 +29,12 @@ def create_debugger_header():
     f.write("   )TheCodeRKS\";\n")
     f.write("static unsigned int __debugger_ui_code_size = "+str(size)+";\n")
     f.close()
+
+
+if len(sys.argv) < 2:
+    print("Usage: cpplize_debugger.py <source_path>")
+    sys.exit(1)
+
+source_path = sys.argv[1]
+
+create_debugger_header(source_path)

--- a/debugger_ui/debugger.py
+++ b/debugger_ui/debugger.py
@@ -100,13 +100,13 @@ def create_layout():
 	# Release this array, we don't need anylonger.
 	frames_description.clear()
 
-	frames_list = sg.Listbox(frame_list_values, key="FRAMES_LIST", size = [45, 30], enable_events=True, horizontal_scroll=True, select_mode=sg.LISTBOX_SELECT_MODE_BROWSE)
-	frames_list = sg.Frame("Frames", layout=[[frames_list]], vertical_alignment="top")
+	frames_list = sg.Listbox(frame_list_values, key="FRAMES_LIST", expand_y=True, expand_x=True, enable_events=True, horizontal_scroll=True, select_mode=sg.LISTBOX_SELECT_MODE_BROWSE, size=(None, None))
+	frames_list = sg.Frame("Frames", layout=[[frames_list]], relief=sg.RELIEF_SUNKEN, vertical_alignment="top", size=(280, 500))
 
 	# --- UI - Compose frame detail ---
 	# Node list
-	nodes_list_listbox = sg.Listbox([], key="NODE_LIST",  size = [45, 0], enable_events=True, horizontal_scroll=True, expand_y=True, expand_x=True, select_mode=sg.LISTBOX_SELECT_MODE_MULTIPLE)
-	nodes_list_listbox = sg.Frame("Nodes", layout=[[nodes_list_listbox]], vertical_alignment="top", expand_y=True, expand_x=True);
+	nodes_list_listbox = sg.Listbox([], key="NODE_LIST",  enable_events=True, horizontal_scroll=True, expand_y=True, expand_x=True, select_mode=sg.LISTBOX_SELECT_MODE_MULTIPLE, size=(None, None))
+	nodes_list_listbox = sg.Frame("Nodes", layout=[[nodes_list_listbox]], vertical_alignment="top", size=(280, 500))
 
 	# Selected nodes title.
 	node_tile_txt = sg.Text("", key="FRAME_SUMMARY", font="Any, " + str(font_size - 1), justification="left", border_width=1, text_color="dark red")
@@ -122,21 +122,21 @@ def create_layout():
 		table_status_header.append("End ("+dir+")")
 		table_status_widths.append(30)
 
-	table_status = sg.Table([], table_status_header, key="TABLE_STATUS", justification='left', auto_size_columns=False, col_widths=table_status_widths, vertical_scroll_only=False, num_rows=38)
-	table_status = sg.Frame("States", layout=[[table_status]], vertical_alignment="top")
+	table_status = sg.Table([], table_status_header, key="TABLE_STATUS", justification='left', size=(None, None), expand_x=True, expand_y=True, auto_size_columns=True, col_widths=table_status_widths, vertical_scroll_only=False, num_rows=38)
+	table_status = sg.Frame("States", layout=[[table_status]], vertical_alignment="top", expand_x=True, expand_y=True)
 
 	# Messages table
 	tables_logs = []
 	for dir in directories:
-		tables_logs.append(sg.Frame("Log: " + dir + " Iteration: ", key=dir+"_FRAME_TABLE_LOG", layout=[[sg.Table([], [" #", "Log"], key=dir+"_TABLE_LOG", justification='left', auto_size_columns=False, col_widths=[4, 70], vertical_scroll_only=False, num_rows=25)]], vertical_alignment="top"))
+		tables_logs.append(sg.Frame("Log: " + dir + " Iteration: ", key=dir+"_FRAME_TABLE_LOG", expand_x=True, expand_y=True, layout=[[sg.Table([], [" #", "Log"], key=dir+"_TABLE_LOG", justification='left', expand_x=True, expand_y=True, auto_size_columns=False, col_widths=(7, 70), vertical_scroll_only=False, num_rows=25)]], vertical_alignment="top"))
 
-	logs = sg.Frame("Messages", layout=[tables_logs], vertical_alignment="top")
+	logs = sg.Frame("Messages", layout=[tables_logs], vertical_alignment="top", expand_x=True, expand_y=True)
 
 	# --- UI - Main Window ---
 	layout = [
 	  [
-			sg.Frame("", [[frames_list], [nodes_list_listbox]], vertical_alignment="top", expand_y=True),
-			sg.Frame("Frame detail", [[node_tile_txt], [table_status], [logs]], key="FRAME_FRAME_DETAIL", vertical_alignment="top")
+			sg.Column(size=(300, None), expand_y=True, vertical_alignment="top", layout=[[frames_list], [nodes_list_listbox]]),
+		  	sg.Column(expand_x=True, expand_y=True, vertical_alignment="top", layout=[[sg.Frame("Frame detail", [[node_tile_txt], [table_status], [logs]], key="FRAME_FRAME_DETAIL", expand_x=True, expand_y=True, vertical_alignment="top")]])
 		],
 		[
 			sg.Button("Exit")
@@ -232,7 +232,7 @@ while True:
 		window["TABLE_STATUS"].update([])
 
 		for dir_name in directories:
-			window[dir_name + "_FRAME_TABLE_LOG"].update("Log: " + dir_name + "Frame: " + str(selected_frame_index) + " Iteration: " + str(used_frame_iteration[dir_name]))
+			window[dir_name + "_FRAME_TABLE_LOG"].update("Log: " + dir_name + " Frame: " + str(selected_frame_index) + " Iteration: " + str(used_frame_iteration[dir_name]))
 			window[dir_name + "_TABLE_LOG"].update([["", "[Nothing for this node]"]])
 
 		if event_values["NODE_LIST"] != []:

--- a/debugger_ui/debugger.py
+++ b/debugger_ui/debugger.py
@@ -13,9 +13,14 @@ font_size = 9
 
 # ---------------------------------------------------------------------------------------- Utilities
 def load_json(path):
+	path = path.strip()
 	if exists(path):
-		with open(path) as f:
-			return json.load(f)
+		with open(path, encoding="utf8") as f:
+			file_data = f.read().replace('\n', '')
+			try:
+				return json.loads(file_data)
+			except json.JSONDecodeError as e:
+				print("JSON loading `", path, "` error `", e, " JSON: ", file_data)
 	return {}
 
 

--- a/debugger_ui/debugger.py
+++ b/debugger_ui/debugger.py
@@ -122,7 +122,7 @@ def create_layout():
 		table_status_header.append("End ("+dir+")")
 		table_status_widths.append(30)
 
-	table_status = sg.Table([], table_status_header, key="TABLE_STATUS", justification='left', size=(None, None), expand_x=True, expand_y=True, auto_size_columns=True, col_widths=table_status_widths, vertical_scroll_only=False, num_rows=38)
+	table_status = sg.Table([], table_status_header, key="TABLE_STATUS", justification='left', expand_x=True, expand_y=True, auto_size_columns=False, col_widths=table_status_widths, vertical_scroll_only=False, num_rows=38)
 	table_status = sg.Frame("States", layout=[[table_status]], vertical_alignment="top", expand_x=True, expand_y=True)
 
 	# Messages table
@@ -196,20 +196,20 @@ while True:
 					frame_data_json = load_json(frame_file_path)
 					frame_data[dir] = frame_data_json
 
-					for node_path in frame_data_json["begin_state"]:
-						if node_path not in nodes_list:
+					for object_name in frame_data_json["begin_state"]:
+						if object_name not in nodes_list:
 							# Add this node to the nodelist
-							nodes_list.append(node_path)
+							nodes_list.append(object_name)
 
-					for node_path in frame_data_json["end_state"]:
-						if node_path not in nodes_list:
+					for object_name in frame_data_json["end_state"]:
+						if object_name not in nodes_list:
 							# Add this node to the nodelist
-							nodes_list.append(node_path)
+							nodes_list.append(object_name)
 
-					for node_path in frame_data_json["node_log"]:
-						if node_path not in nodes_list:
+					for object_name in frame_data_json["node_log"]:
+						if object_name not in nodes_list:
 							# Add this node to the nodelist
-							nodes_list.append(node_path)
+							nodes_list.append(object_name)
 
 
 			# Update the node list.
@@ -247,21 +247,21 @@ while True:
 
 			selected_nodes = event_values["NODE_LIST"]
 
-			for node_path in selected_nodes:
+			for object_name in selected_nodes:
 
 				# First collects the var names
 				vars_names = ["***"]
 				for dir in directories:
 					if dir in frame_data:
 						if "begin_state" in frame_data[dir]:
-							if node_path in frame_data[dir]["begin_state"]:
-								for var_name in frame_data[dir]["begin_state"][node_path]:
+							if object_name in frame_data[dir]["begin_state"]:
+								for var_name in frame_data[dir]["begin_state"][object_name]:
 									if var_name not in vars_names:
 										vars_names.append(var_name)
 
 						if "end_state" in frame_data[dir]:
-							if node_path in frame_data[dir]["end_state"]:
-								for var_name in frame_data[dir]["end_state"][node_path]:
+							if object_name in frame_data[dir]["end_state"]:
+								for var_name in frame_data[dir]["end_state"][object_name]:
 									if var_name not in vars_names:
 										vars_names.append(var_name)
 
@@ -277,7 +277,7 @@ while True:
 					# Special rows
 					if var_name == "***":
 						# This is a special row to signal the start of a new node data
-						row[0] = node_path
+						row[0] = object_name
 						states_table_values.append(row)
 						states_row_colors.append((row_index, "black"))
 						continue
@@ -292,16 +292,16 @@ while True:
 					for dir_i, dir_name in enumerate(directories):
 						if dir_name in frame_data:
 							if "begin_state" in frame_data[dir_name]:
-								if node_path in frame_data[dir_name]["begin_state"]:
-									if var_name in frame_data[dir_name]["begin_state"][node_path]:
+								if object_name in frame_data[dir_name]["begin_state"]:
+									if var_name in frame_data[dir_name]["begin_state"][object_name]:
 										#print(1, " + (", instances_count, " * 0) + ", dir_i)
-										row[1 + (instances_count * 0) + dir_i] = str(frame_data[dir_name]["begin_state"][node_path][var_name])
+										row[1 + (instances_count * 0) + dir_i] = str(frame_data[dir_name]["begin_state"][object_name][var_name])
 
 							if "end_state" in frame_data[dir_name]:
-								if node_path in frame_data[dir_name]["end_state"]:
-									if var_name in frame_data[dir_name]["end_state"][node_path]:
+								if object_name in frame_data[dir_name]["end_state"]:
+									if var_name in frame_data[dir_name]["end_state"][object_name]:
 										#print(1, " + (", instances_count, " * 1) + ", dir_i)
-										row[1 + (instances_count * 1) + dir_i] = str(frame_data[dir_name]["end_state"][node_path][var_name])
+										row[1 + (instances_count * 1) + dir_i] = str(frame_data[dir_name]["end_state"][object_name][var_name])
 
 					# Check if different, so mark a worning.
 					for state_index in range(2):
@@ -318,15 +318,15 @@ while True:
 				for dir_name in directories:
 					if dir_name in frame_data:
 						if "node_log" in frame_data[dir_name]:
-							if node_path in frame_data[dir_name]["node_log"]:
+							if object_name in frame_data[dir_name]["node_log"]:
 
 								table_logs[dir_name] = table_logs.get(dir_name, [])
 								log_row_colors[dir_name] = log_row_colors.get(dir_name, [])
 
-								table_logs[dir_name] += [["", node_path]]
+								table_logs[dir_name] += [["", object_name]]
 								log_row_colors[dir_name] += [(len(table_logs[dir_name]) - 1, "black")]
 
-								for val in frame_data[dir_name]["node_log"][node_path]:
+								for val in frame_data[dir_name]["node_log"][object_name]:
 
 									# Append the log
 									table_logs[dir_name] += [["{:4d}".format(val["i"]), val["m"]]]

--- a/debugger_ui/readme.md
+++ b/debugger_ui/readme.md
@@ -3,11 +3,12 @@
 Requirements
 - Install python
 - Install pip
-- Install PySimpleGUI: `pip install pysymplegui`
+- Install PySimpleGUI: `pip install pysimplegui`
 - Install Tkinter:
   1. Install Tkinter app:
      - Fedora: `sudo dnf install python3-tkinter`
      - Ubuntu: `sudo apt-get install python3-tk`
+     - Windows: Nothing to do
   1. Install python library: `pip install tk`
 
 

--- a/godot4/gd_data_buffer.cpp
+++ b/godot4/gd_data_buffer.cpp
@@ -272,7 +272,7 @@ Variant GdDataBuffer::add_variant(const Variant &p_input) {
 			"Was not possible encode the variant.");
 
 	NS::DataBuffer variant_db;
-	variant_db.begin_write(0);
+	variant_db.begin_write(get_debugger(), 0);
 	variant_db.add(len);
 	variant_db.make_room_pad_to_next_byte();
 	variant_db.make_room_in_bits(len * 8);

--- a/godot4/gd_network_interface.cpp
+++ b/godot4/gd_network_interface.cpp
@@ -295,7 +295,7 @@ void GdNetworkInterface::gd_rpc_receive(const Vector<uint8_t> &p_gd_buffer) {
 		db.get_buffer_mut().get_bytes_mut().push_back(b);
 	}
 
-	db.begin_read();
+	db.begin_read(get_debugger());
 	rpc_receive(
 			owner->get_multiplayer()->get_remote_sender_id(),
 			db);

--- a/scene_synchronizer.cpp
+++ b/scene_synchronizer.cpp
@@ -1833,13 +1833,13 @@ void NoNetSynchronizer::process(float p_delta) {
 		const uint32_t frame_index = frame_count;
 		frame_count += 1;
 
-		scene_synchronizer->get_debugger().scene_sync_process_start(scene_synchronizer);
+		scene_synchronizer->get_debugger().scene_sync_process_start(*scene_synchronizer);
 
 		// Process the scene.
 		scene_synchronizer->process_functions__execute();
 		scene_synchronizer->detect_and_signal_changed_variables(NetEventFlag::CHANGE);
 
-		scene_synchronizer->get_debugger().scene_sync_process_end(scene_synchronizer);
+		scene_synchronizer->get_debugger().scene_sync_process_end(*scene_synchronizer);
 		scene_synchronizer->get_debugger().write_dump(0, frame_index);
 		scene_synchronizer->get_debugger().start_new_frame();
 	}
@@ -1907,7 +1907,7 @@ void ServerSynchronizer::process(float p_delta) {
 	for (int i = 0; i < sub_process_count; i++) {
 		epoch += 1;
 
-		scene_synchronizer->get_debugger().scene_sync_process_start(scene_synchronizer);
+		scene_synchronizer->get_debugger().scene_sync_process_start(*scene_synchronizer);
 
 		// Process the scene
 		scene_synchronizer->process_functions__execute();
@@ -1915,7 +1915,7 @@ void ServerSynchronizer::process(float p_delta) {
 
 		process_snapshot_notificator();
 
-		scene_synchronizer->get_debugger().scene_sync_process_end(scene_synchronizer);
+		scene_synchronizer->get_debugger().scene_sync_process_end(*scene_synchronizer);
 
 #if NS_DEBUG_ENABLED
 		// Write the debug dump for each peer.
@@ -3441,7 +3441,7 @@ void ClientSynchronizer::process_simulation(float p_delta) {
 		NS_PROFILE_NAMED_WITH_INFO("PROCESS", sub_perf_info)
 #endif
 		scene_synchronizer->get_debugger().print(VERBOSE, "ClientSynchronizer::process::sub_process " + std::to_string(sub_ticks), scene_synchronizer->get_network_interface().get_owner_name());
-		scene_synchronizer->get_debugger().scene_sync_process_start(scene_synchronizer);
+		scene_synchronizer->get_debugger().scene_sync_process_start(*scene_synchronizer);
 
 		// Process the scene.
 		scene_synchronizer->process_functions__execute();
@@ -3453,7 +3453,7 @@ void ClientSynchronizer::process_simulation(float p_delta) {
 		}
 
 		sub_ticks -= 1;
-		scene_synchronizer->get_debugger().scene_sync_process_end(scene_synchronizer);
+		scene_synchronizer->get_debugger().scene_sync_process_end(*scene_synchronizer);
 
 #if NS_DEBUG_ENABLED
 		if (sub_ticks > 0) {

--- a/scene_synchronizer.h
+++ b/scene_synchronizer.h
@@ -50,7 +50,7 @@ public:
 	/// and the server and allows to add custom data to it.
 	/// Returns true if the r_custom_data is set.
 	virtual bool snapshot_get_custom_data(
-			const struct SyncGroup *p_group,
+			const SyncGroup *p_group,
 			/// This is set to "true" when the current snapshot contains only
 			/// part of the changed objects.
 			bool p_is_partial_update,
@@ -58,7 +58,7 @@ public:
 			/// and contains the indices of the simulated objects info that you
 			/// can use to retrieve the ObjectData using `p_group->get_simulated_sync_objects()[index].od`.
 			const std::vector<std::size_t> &p_partial_update_simulated_objects_info_indices,
-			struct VarData &r_custom_data) {
+			VarData &r_custom_data) {
 		return false;
 	}
 
@@ -71,8 +71,8 @@ public:
 	/// from the server.
 	virtual bool snapshot_merge_custom_data_for_partial_update(
 			const std::vector<ObjectNetId> &p_partial_update_objects,
-			struct VarData &r_custom_data,
-			const struct VarData &p_custom_data_from_server_snapshot) {
+			VarData &r_custom_data,
+			const VarData &p_custom_data_from_server_snapshot) {
 		return false;
 	}
 
@@ -192,8 +192,8 @@ public:
 	};
 
 protected:
-	static void (*var_data_encode_func)(class DataBuffer &r_buffer, const NS::VarData &p_val);
-	static void (*var_data_decode_func)(NS::VarData &r_val, DataBuffer &p_buffer, std::uint8_t p_var_type);
+	static void (*var_data_encode_func)(class DataBuffer &r_buffer, const VarData &p_val);
+	static void (*var_data_decode_func)(VarData &r_val, DataBuffer &p_buffer, std::uint8_t p_var_type);
 	static bool (*var_data_compare_func)(const VarData &p_A, const VarData &p_B);
 	static std::string (*var_data_stringify_func)(const VarData &p_var_data, bool p_verbose);
 
@@ -289,8 +289,6 @@ protected: // ----------------------------------------------------- User defined
 	class NetworkInterface *network_interface = nullptr;
 	SynchronizerManager *synchronizer_manager = nullptr;
 
-	SceneSynchronizerDebugger *debugger = nullptr;
-
 protected: // -------------------------------------------------------- Internals
 	RpcHandle<DataBuffer &> rpc_handler_state;
 	RpcHandle<> rpc_handler_notify_need_full_snapshot;
@@ -357,8 +355,8 @@ public:
 
 public: // -------------------------------------------------------- Manager APIs
 	static void install_synchronizer(
-			void (*p_var_data_encode_func)(DataBuffer &r_buffer, const NS::VarData &p_val),
-			void (*p_var_data_decode_func)(NS::VarData &r_val, DataBuffer &p_buffer, std::uint8_t p_variable_type),
+			void (*p_var_data_encode_func)(DataBuffer &r_buffer, const VarData &p_val),
+			void (*p_var_data_decode_func)(VarData &r_val, DataBuffer &p_buffer, std::uint8_t p_variable_type),
 			bool (*p_var_data_compare_func)(const VarData &p_A, const VarData &p_B),
 			std::string (*p_var_data_stringify_func)(const VarData &p_var_data, bool p_verbose),
 			void (*p_print_line_func)(const std::string &p_str),
@@ -378,7 +376,7 @@ public: // -------------------------------------------------------- Manager APIs
 	void on_app_object_removed(ObjectHandle p_app_object_handle);
 
 public:
-	static void var_data_encode(DataBuffer &r_buffer, const NS::VarData &p_val, std::uint8_t p_variable_type);
+	static void var_data_encode(DataBuffer &r_buffer, const VarData &p_val, std::uint8_t p_variable_type);
 	static void var_data_decode(VarData &r_val, DataBuffer &p_buffer, std::uint8_t p_variable_type);
 	static bool var_data_compare(const VarData &p_A, const VarData &p_B);
 	static std::string var_data_stringify(const VarData &p_var_data, bool p_verbose = false);
@@ -615,7 +613,7 @@ public: // ---------------------------------------------------------------- APIs
 	float sync_group_get_simulated_partial_update_timespan_seconds(ObjectLocalId p_id, SyncGroupId p_group_id) const;
 
 	/// Use `std::move()` to transfer `p_new_realtime_object` and `p_new_trickled_objects`.
-	void sync_group_replace_objects(SyncGroupId p_group_id, std::vector<NS::SyncGroup::SimulatedObjectInfo> &&p_new_realtime_objects, std::vector<NS::SyncGroup::TrickledObjectInfo> &&p_new_trickled_objects);
+	void sync_group_replace_objects(SyncGroupId p_group_id, std::vector<SyncGroup::SimulatedObjectInfo> &&p_new_realtime_objects, std::vector<SyncGroup::TrickledObjectInfo> &&p_new_trickled_objects);
 
 	void sync_group_remove_all_objects(SyncGroupId p_group_id);
 	void sync_group_move_peer_to(int p_peer_id, SyncGroupId p_group_id);
@@ -674,7 +672,7 @@ public: // ---------------------------------------------------------------- APIs
 	bool client_is_simulated_object(ObjectLocalId p_id) const;
 
 	SceneSynchronizerDebugger &get_debugger() const {
-		return *debugger;
+		return network_interface->get_debugger();
 	};
 
 public: // ------------------------------------------------------------ INTERNAL
@@ -810,7 +808,7 @@ class ServerSynchronizer final : public Synchronizer {
 	float objects_relevancy_update_timer = 0.0;
 	uint32_t epoch = 0;
 	/// This array contains a map between the peers and the relevant objects.
-	std::vector<NS::SyncGroup> sync_groups;
+	std::vector<SyncGroup> sync_groups;
 	std::vector<ObjectData *> active_objects;
 
 	enum class SnapshotObjectGeneratorMode {
@@ -844,7 +842,7 @@ public:
 
 	SyncGroupId sync_group_create();
 	/// IMPORTANT: The pointer returned is invalid at the end of the scope executing this function. Never store it.
-	const NS::SyncGroup *sync_group_get(SyncGroupId p_group_id) const;
+	const SyncGroup *sync_group_get(SyncGroupId p_group_id) const;
 
 	void sync_group_add_object(ObjectData *p_object_data, SyncGroupId p_group_id, bool p_realtime);
 	void sync_group_remove_object(ObjectData *p_object_data, SyncGroupId p_group_id);
@@ -852,7 +850,7 @@ public:
 	void sync_group_set_simulated_partial_update_timespan_seconds(const ObjectData &p_object_data, SyncGroupId p_group_id, bool p_partial_update_enabled, float p_update_timespan);
 	bool sync_group_is_simulated_partial_updating(const ObjectData &p_object_data, SyncGroupId p_group_id) const;
 	float sync_group_get_simulated_partial_update_timespan_seconds(const ObjectData &p_object_data, SyncGroupId p_group_id) const;
-	void sync_group_replace_object(SyncGroupId p_group_id, std::vector<SyncGroup::SimulatedObjectInfo> &&p_new_realtime_nodes, std::vector<NS::SyncGroup::TrickledObjectInfo> &&p_new_trickled_nodes);
+	void sync_group_replace_object(SyncGroupId p_group_id, std::vector<SyncGroup::SimulatedObjectInfo> &&p_new_realtime_nodes, std::vector<SyncGroup::TrickledObjectInfo> &&p_new_trickled_nodes);
 	void sync_group_remove_all_objects(SyncGroupId p_group_id);
 	void sync_group_move_peer_to(int p_peer_id, SyncGroupId p_group_id);
 	void sync_group_update(int p_peer_id);
@@ -971,9 +969,9 @@ public:
 		TrickledSyncInterpolationData() = delete;
 
 		TrickledSyncInterpolationData(const TrickledSyncInterpolationData &p_dss) :
+			od(p_dss.od),
 			past_epoch_buffer(p_dss.past_epoch_buffer),
 			future_epoch_buffer(p_dss.future_epoch_buffer),
-			od(p_dss.od),
 			past_epoch(p_dss.past_epoch),
 			future_epoch(p_dss.future_epoch),
 			epochs_timespan(p_dss.epochs_timespan),

--- a/tests/local_network.cpp
+++ b/tests/local_network.cpp
@@ -208,6 +208,9 @@ NS_NAMESPACE_END
 
 /// Test that the LocalNetwork is able to sync stuff.
 void NS_Test::test_local_network() {
+	NS::SceneSynchronizerDebugger debugger;
+	NS::SceneSynchronizerDebugger::__set_singleton(&debugger);
+	
 	NS::LocalNetworkProps network_properties;
 
 	NS::LocalNetwork server;
@@ -442,4 +445,6 @@ void NS_Test::test_local_network() {
 
 	NS_ASSERT_COND(server_rpc_executed_by[2] == server.get_peer()); // Make sure this was executed locally too.
 	NS_ASSERT_COND(peer_2_rpc_executed_by[3] == server.get_peer()); // Make sure this was executed remotely.
+	
+	NS::SceneSynchronizerDebugger::__set_singleton(nullptr);
 }

--- a/tests/local_network.cpp
+++ b/tests/local_network.cpp
@@ -66,7 +66,7 @@ void LocalNetwork::register_object(LocalNetworkInterface &p_interface) {
 	registered_objects.insert(std::make_pair(p_interface.get_owner_name(), &p_interface));
 }
 
-void LocalNetwork::rpc_send(std::string p_object_name, int p_peer_recipient, bool p_reliable, NS::DataBuffer &&p_data_buffer) {
+void LocalNetwork::rpc_send(std::string p_object_name, int p_peer_recipient, bool p_reliable, DataBuffer &&p_data_buffer) {
 	auto object_map_it = registered_objects.find(p_object_name);
 	NS_ASSERT_COND(object_map_it != registered_objects.end());
 
@@ -186,7 +186,7 @@ bool LocalNetworkInterface::is_local_peer_server() const {
 	return network->get_peer() == 1;
 }
 
-void LocalNetworkInterface::rpc_send(int p_peer_recipient, bool p_reliable, NS::DataBuffer &&p_data_buffer) {
+void LocalNetworkInterface::rpc_send(int p_peer_recipient, bool p_reliable, DataBuffer &&p_data_buffer) {
 	NS_ENSURE(network);
 	network->rpc_send(get_owner_name(), p_peer_recipient, p_reliable, std::move(p_data_buffer));
 }
@@ -208,9 +208,6 @@ NS_NAMESPACE_END
 
 /// Test that the LocalNetwork is able to sync stuff.
 void NS_Test::test_local_network() {
-	NS::SceneSynchronizerDebugger debugger;
-	NS::SceneSynchronizerDebugger::__set_singleton(&debugger);
-	
 	NS::LocalNetworkProps network_properties;
 
 	NS::LocalNetwork server;
@@ -445,6 +442,4 @@ void NS_Test::test_local_network() {
 
 	NS_ASSERT_COND(server_rpc_executed_by[2] == server.get_peer()); // Make sure this was executed locally too.
 	NS_ASSERT_COND(peer_2_rpc_executed_by[3] == server.get_peer()); // Make sure this was executed remotely.
-	
-	NS::SceneSynchronizerDebugger::__set_singleton(nullptr);
 }

--- a/tests/local_network.h
+++ b/tests/local_network.h
@@ -30,7 +30,7 @@ struct PendingPacket {
 	float delay = 0.0;
 	int peer_recipient = -1;
 	std::string object_name;
-	NS::DataBuffer data_buffer;
+	DataBuffer data_buffer;
 };
 
 class LocalNetwork {
@@ -48,8 +48,8 @@ class LocalNetwork {
 public:
 	LocalNetworkProps *network_properties = nullptr;
 
-	NS::Processor<int> connected_event;
-	NS::Processor<int> disconnected_event;
+	Processor<int> connected_event;
+	Processor<int> disconnected_event;
 
 public:
 	int get_peer() const;

--- a/tests/test_data_buffer.cpp
+++ b/tests/test_data_buffer.cpp
@@ -3,6 +3,7 @@
 #include "../core/data_buffer.h"
 #include "../core/ensure.h"
 #include "../core/net_math.h"
+#include "NetworkSynchronizer/core/scene_synchronizer_debugger.h"
 
 inline std::vector<std::int64_t> int_values(NS::DataBuffer::CompressionLevel p_compression_level) {
 	std::vector<int64_t> values;
@@ -876,6 +877,8 @@ void test_data_buffer_reading_failing() {
 }
 
 void NS_Test::test_data_buffer() {
+	NS::SceneSynchronizerDebugger debugger;
+	NS::SceneSynchronizerDebugger::__set_singleton(&debugger);
 	test_data_buffer_string();
 	test_data_buffer_u16string();
 	test_data_buffer_bool();
@@ -902,4 +905,5 @@ void NS_Test::test_data_buffer() {
 	test_data_buffer_skip();
 	test_data_buffer_writing_failing();
 	test_data_buffer_reading_failing();
+	NS::SceneSynchronizerDebugger::__set_singleton(nullptr);
 }

--- a/tests/test_data_buffer.cpp
+++ b/tests/test_data_buffer.cpp
@@ -3,7 +3,9 @@
 #include "../core/data_buffer.h"
 #include "../core/ensure.h"
 #include "../core/net_math.h"
-#include "NetworkSynchronizer/core/scene_synchronizer_debugger.h"
+#include "../core/scene_synchronizer_debugger.h"
+
+NS::SceneSynchronizerDebugger debugger;
 
 inline std::vector<std::int64_t> int_values(NS::DataBuffer::CompressionLevel p_compression_level) {
 	std::vector<int64_t> values;
@@ -309,12 +311,12 @@ inline std::vector<std::tuple<T, T, T>> vector_3_values(NS::DataBuffer::Compress
 
 void test_data_buffer_string() {
 	NS::DataBuffer db;
-	db.begin_write(0);
+	db.begin_write(debugger, 0);
 
 	std::string abc_1("abc_1");
 	db.add(abc_1);
 
-	db.begin_read();
+	db.begin_read(debugger);
 	std::string abc_1_r;
 	db.read(abc_1_r);
 
@@ -324,7 +326,7 @@ void test_data_buffer_string() {
 void test_data_buffer_u16string() {
 	{
 		NS::DataBuffer db;
-		db.begin_write(0);
+		db.begin_write(debugger, 0);
 
 		std::u16string abc_1(u"abc_1");
 		db.add(abc_1);
@@ -335,7 +337,7 @@ void test_data_buffer_u16string() {
 		std::u16string abc_3(u"abc_3");
 		db.add(abc_3);
 
-		db.begin_read();
+		db.begin_read(debugger);
 		std::u16string abc_1_r;
 		db.read(abc_1_r);
 
@@ -355,23 +357,23 @@ void test_data_buffer_bool() {
 	{
 		NS::DataBuffer buffer;
 
-		buffer.begin_write(0);
+		buffer.begin_write(debugger, 0);
 		buffer.add_bool(true);
 
 		NS_ASSERT_COND(buffer.get_bit_offset() == buffer.get_bit_taken(NS::DataBuffer::DATA_TYPE_BOOL, NS::DataBuffer::COMPRESSION_LEVEL_0));
 
-		buffer.begin_read();
+		buffer.begin_read(debugger);
 		NS_ASSERT_COND_MSG(buffer.read_bool() == true, "Should read the same value");
 	}
 	{
 		NS::DataBuffer buffer;
 
-		buffer.begin_write(0);
+		buffer.begin_write(debugger, 0);
 		buffer.add_bool(false);
 
 		NS_ASSERT_COND(buffer.get_bit_offset() == buffer.get_bit_taken(NS::DataBuffer::DATA_TYPE_BOOL, NS::DataBuffer::COMPRESSION_LEVEL_0));
 
-		buffer.begin_read();
+		buffer.begin_read(debugger);
 		NS_ASSERT_COND_MSG(buffer.read_bool() == false, "Should read the same value");
 	}
 }
@@ -384,7 +386,7 @@ void test_data_buffer_int() {
 
 		for (int i = 0; i < values.size(); ++i) {
 			NS::DataBuffer buffer;
-			buffer.begin_write(0);
+			buffer.begin_write(debugger, 0);
 
 			const std::int64_t value = values[i];
 
@@ -392,7 +394,7 @@ void test_data_buffer_int() {
 			NS_ASSERT_COND(buffer.get_bit_offset() == buffer.get_bit_taken(NS::DataBuffer::DATA_TYPE_INT, compression_level));
 			NS_ASSERT_COND(!buffer.is_buffer_failed());
 
-			buffer.begin_read();
+			buffer.begin_read(debugger);
 			const std::int64_t read_value = buffer.read_int(compression_level);
 			const bool is_equal = read_value == value;
 			NS_ASSERT_COND(!buffer.is_buffer_failed());
@@ -409,7 +411,7 @@ void test_data_buffer_uint() {
 
 		for (int i = 0; i < values.size(); ++i) {
 			NS::DataBuffer buffer;
-			buffer.begin_write(0);
+			buffer.begin_write(debugger, 0);
 
 			const std::uint64_t value = values[i];
 
@@ -417,7 +419,7 @@ void test_data_buffer_uint() {
 			NS_ASSERT_COND(buffer.get_bit_offset() == buffer.get_bit_taken(NS::DataBuffer::DATA_TYPE_UINT, compression_level));
 			NS_ASSERT_COND(!buffer.is_buffer_failed());
 
-			buffer.begin_read();
+			buffer.begin_read(debugger);
 			const std::uint64_t read_value = buffer.read_uint(compression_level);
 			const bool is_equal = read_value == value;
 			NS_ASSERT_COND(!buffer.is_buffer_failed());
@@ -436,7 +438,7 @@ void test_data_buffer_real() {
 
 		for (int i = 0; i < values.size(); ++i) {
 			NS::DataBuffer buffer;
-			buffer.begin_write(0);
+			buffer.begin_write(debugger, 0);
 
 			const T value = values[i];
 
@@ -449,7 +451,7 @@ void test_data_buffer_real() {
 			}
 			NS_ASSERT_COND(!buffer.is_buffer_failed());
 
-			buffer.begin_read();
+			buffer.begin_read(debugger);
 			T read_value;
 			buffer.read_real(read_value, compression_level);
 			const bool is_equal = NS::MathFunc::is_equal_approx<T>(read_value, value, epsilon);
@@ -469,7 +471,7 @@ void test_data_buffer_positive_unit_real() {
 
 		for (int i = 0; i < values.size(); ++i) {
 			NS::DataBuffer buffer;
-			buffer.begin_write(0);
+			buffer.begin_write(debugger, 0);
 
 			const T value = values[i];
 
@@ -477,7 +479,7 @@ void test_data_buffer_positive_unit_real() {
 			NS_ASSERT_COND(buffer.get_bit_offset() == buffer.get_bit_taken(NS::DataBuffer::DATA_TYPE_POSITIVE_UNIT_REAL, compression_level));
 			NS_ASSERT_COND(!buffer.is_buffer_failed());
 
-			buffer.begin_read();
+			buffer.begin_read(debugger);
 			const T read_value = buffer.read_positive_unit_real(compression_level);
 			const bool is_equal = NS::MathFunc::is_equal_approx<T>(read_value, value, epsilon);
 			NS_ASSERT_COND(!buffer.is_buffer_failed());
@@ -498,7 +500,7 @@ void test_data_buffer_unit_real() {
 		for (float factor : factors) {
 			for (int i = 0; i < values.size(); ++i) {
 				NS::DataBuffer buffer;
-				buffer.begin_write(0);
+				buffer.begin_write(debugger, 0);
 
 				const T value = values[i] * factor;
 
@@ -506,7 +508,7 @@ void test_data_buffer_unit_real() {
 				NS_ASSERT_COND(buffer.get_bit_offset() == buffer.get_bit_taken(NS::DataBuffer::DATA_TYPE_UNIT_REAL, compression_level));
 				NS_ASSERT_COND(!buffer.is_buffer_failed());
 
-				buffer.begin_read();
+				buffer.begin_read(debugger);
 				const T read_value = buffer.read_unit_real(compression_level);
 				const bool is_equal = NS::MathFunc::is_equal_approx<T>(read_value, value, epsilon);
 				NS_ASSERT_COND(!buffer.is_buffer_failed());
@@ -526,7 +528,7 @@ void test_data_buffer_vector_2() {
 
 		for (int i = 0; i < values.size(); ++i) {
 			NS::DataBuffer buffer;
-			buffer.begin_write(0);
+			buffer.begin_write(debugger, 0);
 
 			const std::pair<T, T> value = values[i];
 
@@ -539,7 +541,7 @@ void test_data_buffer_vector_2() {
 			}
 			NS_ASSERT_COND(!buffer.is_buffer_failed());
 
-			buffer.begin_read();
+			buffer.begin_read(debugger);
 			T read_x;
 			T read_y;
 			buffer.read_vector2(read_x, read_y, compression_level);
@@ -560,7 +562,7 @@ void test_data_buffer_normalized_vector_2() {
 
 		for (int i = 0; i < values.size(); ++i) {
 			NS::DataBuffer buffer;
-			buffer.begin_write(0);
+			buffer.begin_write(debugger, 0);
 
 			const std::pair<T, T> value = values[i];
 
@@ -568,7 +570,7 @@ void test_data_buffer_normalized_vector_2() {
 			NS_ASSERT_COND(!buffer.is_buffer_failed());
 			NS_ASSERT_COND(buffer.get_bit_offset() == buffer.get_bit_taken(NS::DataBuffer::DATA_TYPE_NORMALIZED_VECTOR2, compression_level));
 
-			buffer.begin_read();
+			buffer.begin_read(debugger);
 			T read_x;
 			T read_y;
 			buffer.read_normalized_vector2(read_x, read_y, compression_level);
@@ -589,7 +591,7 @@ void test_data_buffer_vector_3() {
 
 		for (int i = 0; i < values.size(); ++i) {
 			NS::DataBuffer buffer;
-			buffer.begin_write(0);
+			buffer.begin_write(debugger, 0);
 
 			const std::tuple<T, T, T> value = values[i];
 
@@ -602,7 +604,7 @@ void test_data_buffer_vector_3() {
 			}
 			NS_ASSERT_COND(!buffer.is_buffer_failed());
 
-			buffer.begin_read();
+			buffer.begin_read(debugger);
 			T read_x;
 			T read_y;
 			T read_z;
@@ -625,7 +627,7 @@ void test_data_buffer_normalized_vector_3() {
 
 		for (int i = 0; i < values.size(); ++i) {
 			NS::DataBuffer buffer;
-			buffer.begin_write(0);
+			buffer.begin_write(debugger, 0);
 
 			const std::tuple<T, T, T> value = values[i];
 
@@ -633,7 +635,7 @@ void test_data_buffer_normalized_vector_3() {
 			NS_ASSERT_COND(!buffer.is_buffer_failed());
 			NS_ASSERT_COND(buffer.get_bit_offset() == buffer.get_bit_taken(NS::DataBuffer::DATA_TYPE_NORMALIZED_VECTOR3, compression_level));
 
-			buffer.begin_read();
+			buffer.begin_read(debugger);
 			T read_x;
 			T read_y;
 			T read_z;
@@ -647,7 +649,7 @@ void test_data_buffer_normalized_vector_3() {
 
 void test_data_buffer_bits() {
 	NS::DataBuffer buffer;
-	buffer.begin_write(0);
+	buffer.begin_write(debugger, 0);
 
 	buffer.add_bool(false);
 	buffer.add_bool(true);
@@ -658,7 +660,7 @@ void test_data_buffer_bits() {
 	buffer.add_bits(bytes.data(), int(bytes.size() * 8));
 	NS_ASSERT_COND(!buffer.is_buffer_failed());
 
-	buffer.begin_read();
+	buffer.begin_read(debugger);
 	buffer.read_bool();
 	buffer.read_bool();
 	buffer.read_bool();
@@ -674,13 +676,13 @@ void test_data_buffer_bits() {
 
 void test_data_buffer_data_buffer() {
 	NS::DataBuffer main_buffer;
-	main_buffer.begin_write(0);
+	main_buffer.begin_write(debugger, 0);
 
 	const std::vector<uint8_t> bytes = byte_values();
 
 	{
 		NS::DataBuffer buffer;
-		buffer.begin_write(0);
+		buffer.begin_write(debugger, 0);
 
 		buffer.add_bool(false);
 		buffer.add_bool(true);
@@ -696,13 +698,13 @@ void test_data_buffer_data_buffer() {
 
 	{
 		NS::DataBuffer buffer;
-		buffer.begin_write(0);
+		buffer.begin_write(debugger, 0);
 
-		main_buffer.begin_read();
+		main_buffer.begin_read(debugger);
 		main_buffer.read_data_buffer(buffer);
 		NS_ASSERT_COND(!main_buffer.is_buffer_failed());
 
-		buffer.begin_read();
+		buffer.begin_read(debugger);
 		buffer.read_bool();
 		buffer.read_bool();
 		buffer.read_bool();
@@ -719,14 +721,14 @@ void test_data_buffer_data_buffer() {
 
 void test_data_buffer_seek() {
 	NS::DataBuffer buffer;
-	buffer.begin_write(0);
+	buffer.begin_write(debugger, 0);
 	buffer.add_bool(true);
 	buffer.add_bool(false);
 
 	buffer.seek(-1);
 	NS_ASSERT_COND_MSG(buffer.get_bit_offset() == 2, "Bit offset should fail for negative values");
 
-	buffer.begin_read();
+	buffer.begin_read(debugger);
 	NS_ASSERT_COND(buffer.get_bit_offset() == 0);
 
 	buffer.seek(1);
@@ -743,33 +745,33 @@ void test_data_buffer_metadata() {
 	bool value[] = { false, true };
 
 	for (int i = 0; i < 2; i++) {
-		const int metadata_size = NS::DataBuffer::get_bit_taken(NS::DataBuffer::DATA_TYPE_BOOL, NS::DataBuffer::COMPRESSION_LEVEL_0);
 		NS::DataBuffer buffer;
-		buffer.begin_write(metadata_size);
+		const int metadata_size = buffer.get_bit_taken(NS::DataBuffer::DATA_TYPE_BOOL, NS::DataBuffer::COMPRESSION_LEVEL_0);
+		buffer.begin_write(debugger, metadata_size);
 		buffer.add_bool(metadata[i]);
 		buffer.add_bool(value[i]);
-		buffer.begin_read();
+		buffer.begin_read(debugger);
 		NS_ASSERT_COND_MSG(buffer.read_bool() == metadata[i], "Should return correct metadata");
 		NS_ASSERT_COND_MSG(buffer.read_bool() == value[i], "Should return correct value after metadata");
 		NS_ASSERT_COND_MSG(buffer.get_metadata_size() == metadata_size, "Metadata size should be equal to expected");
-		NS_ASSERT_COND_MSG(buffer.size() == NS::DataBuffer::get_bit_taken(NS::DataBuffer::DATA_TYPE_BOOL, NS::DataBuffer::COMPRESSION_LEVEL_0), "Size should be equal to expected");
-		NS_ASSERT_COND_MSG(buffer.total_size() == NS::DataBuffer::get_bit_taken(NS::DataBuffer::DATA_TYPE_BOOL, NS::DataBuffer::COMPRESSION_LEVEL_0) + metadata_size, "Total size should be equal to expected");
+		NS_ASSERT_COND_MSG(buffer.size() == buffer.get_bit_taken(NS::DataBuffer::DATA_TYPE_BOOL, NS::DataBuffer::COMPRESSION_LEVEL_0), "Size should be equal to expected");
+		NS_ASSERT_COND_MSG(buffer.total_size() == buffer.get_bit_taken(NS::DataBuffer::DATA_TYPE_BOOL, NS::DataBuffer::COMPRESSION_LEVEL_0) + metadata_size, "Total size should be equal to expected");
 	}
 }
 
 void test_data_buffer_zero() {
 	constexpr NS::DataBuffer::CompressionLevel compression = NS::DataBuffer::COMPRESSION_LEVEL_0;
 	NS::DataBuffer buffer;
-	buffer.begin_write(0);
+	buffer.begin_write(debugger, 0);
 	buffer.add_int(-1, compression);
 	buffer.zero();
-	buffer.begin_read();
+	buffer.begin_read(debugger);
 	NS_ASSERT_COND_MSG(buffer.read_int(compression) == 0, "Should return 0");
 }
 
 void test_data_buffer_shrinking() {
 	NS::DataBuffer buffer;
-	buffer.begin_write(0);
+	buffer.begin_write(debugger, 0);
 	for (int i = 0; i < 2; ++i) {
 		buffer.add_real(3.14, NS::DataBuffer::COMPRESSION_LEVEL_0);
 	}
@@ -790,46 +792,47 @@ void test_data_buffer_skip() {
 	const bool value = true;
 
 	NS::DataBuffer buffer;
+	buffer.begin_write(debugger, 0);
 	buffer.add_bool(!value);
 	buffer.add_bool(value);
 
-	buffer.begin_read();
-	buffer.seek(NS::DataBuffer::get_bit_taken(NS::DataBuffer::DATA_TYPE_BOOL, NS::DataBuffer::COMPRESSION_LEVEL_0));
+	buffer.begin_read(debugger);
+	buffer.seek(buffer.get_bit_taken(NS::DataBuffer::DATA_TYPE_BOOL, NS::DataBuffer::COMPRESSION_LEVEL_0));
 	NS_ASSERT_COND_MSG(buffer.read_bool() == value, "Should read the same value");
 }
 
 void test_data_buffer_writing_failing() {
 	{
 		NS::DataBuffer buffer;
-		buffer.begin_read();
+		buffer.begin_read(debugger);
 		NS_ASSERT_COND(!buffer.is_buffer_failed());
 		buffer.add_bool(true);
 		NS_ASSERT_COND(buffer.is_buffer_failed());
 	}
 	{
 		NS::DataBuffer buffer;
-		buffer.begin_read();
+		buffer.begin_read(debugger);
 		NS_ASSERT_COND(!buffer.is_buffer_failed());
 		buffer.add_int(1, NS::DataBuffer::COMPRESSION_LEVEL_0);
 		NS_ASSERT_COND(buffer.is_buffer_failed());
 	}
 	{
 		NS::DataBuffer buffer;
-		buffer.begin_read();
+		buffer.begin_read(debugger);
 		NS_ASSERT_COND(!buffer.is_buffer_failed());
 		buffer.add_uint(1, NS::DataBuffer::COMPRESSION_LEVEL_0);
 		NS_ASSERT_COND(buffer.is_buffer_failed());
 	}
 	{
 		NS::DataBuffer buffer;
-		buffer.begin_read();
+		buffer.begin_read(debugger);
 		NS_ASSERT_COND(!buffer.is_buffer_failed());
 		buffer.add_normalized_vector2(0.f, 0.f, NS::DataBuffer::COMPRESSION_LEVEL_0);
 		NS_ASSERT_COND(buffer.is_buffer_failed());
 	}
 	{
 		NS::DataBuffer buffer;
-		buffer.begin_read();
+		buffer.begin_read(debugger);
 		NS_ASSERT_COND(!buffer.is_buffer_failed());
 		buffer.add_normalized_vector3(0.f, 0.f, 0.f, NS::DataBuffer::COMPRESSION_LEVEL_0);
 		NS_ASSERT_COND(buffer.is_buffer_failed());
@@ -839,28 +842,28 @@ void test_data_buffer_writing_failing() {
 void test_data_buffer_reading_failing() {
 	{
 		NS::DataBuffer buffer;
-		buffer.begin_write(0);
+		buffer.begin_write(debugger, 0);
 		NS_ASSERT_COND(!buffer.is_buffer_failed());
 		buffer.read_bool();
 		NS_ASSERT_COND(buffer.is_buffer_failed());
 	}
 	{
 		NS::DataBuffer buffer;
-		buffer.begin_write(0);
+		buffer.begin_write(debugger, 0);
 		NS_ASSERT_COND(!buffer.is_buffer_failed());
 		buffer.read_int(NS::DataBuffer::COMPRESSION_LEVEL_0);
 		NS_ASSERT_COND(buffer.is_buffer_failed());
 	}
 	{
 		NS::DataBuffer buffer;
-		buffer.begin_write(0);
+		buffer.begin_write(debugger, 0);
 		NS_ASSERT_COND(!buffer.is_buffer_failed());
 		buffer.read_uint(NS::DataBuffer::COMPRESSION_LEVEL_0);
 		NS_ASSERT_COND(buffer.is_buffer_failed());
 	}
 	{
 		NS::DataBuffer buffer;
-		buffer.begin_write(0);
+		buffer.begin_write(debugger, 0);
 		NS_ASSERT_COND(!buffer.is_buffer_failed());
 		double x, y;
 		buffer.read_normalized_vector2(x, y, NS::DataBuffer::COMPRESSION_LEVEL_0);
@@ -868,7 +871,7 @@ void test_data_buffer_reading_failing() {
 	}
 	{
 		NS::DataBuffer buffer;
-		buffer.begin_write(0);
+		buffer.begin_write(debugger, 0);
 		NS_ASSERT_COND(!buffer.is_buffer_failed());
 		double x, y, z;
 		buffer.read_normalized_vector3(x, y, z, NS::DataBuffer::COMPRESSION_LEVEL_0);
@@ -877,8 +880,6 @@ void test_data_buffer_reading_failing() {
 }
 
 void NS_Test::test_data_buffer() {
-	NS::SceneSynchronizerDebugger debugger;
-	NS::SceneSynchronizerDebugger::__set_singleton(&debugger);
 	test_data_buffer_string();
 	test_data_buffer_u16string();
 	test_data_buffer_bool();
@@ -905,5 +906,4 @@ void NS_Test::test_data_buffer() {
 	test_data_buffer_skip();
 	test_data_buffer_writing_failing();
 	test_data_buffer_reading_failing();
-	NS::SceneSynchronizerDebugger::__set_singleton(nullptr);
 }

--- a/tests/test_simulation.cpp
+++ b/tests/test_simulation.cpp
@@ -888,8 +888,6 @@ struct TestObjectSimulationWithPartialUpdateAndCustomDataAndDoll : public TestOb
 
 		// Add the controlled object 1 to the scene 2.
 		controlled_obj_1_p2 = peer_2_scene.add_object<TSLocalNetworkedController>("controller_1", peer_1_scene.get_peer());
-		peer_1_scene.scene_sync->set_debug_rewindings_enabled(true);
-		SceneSynchronizerDebugger::singleton()->set_log_level(NS::INFO);
 
 		controlled_obj_1_p2->set_position(Vec3(1.0, 1.0, 1.0));
 		controlled_obj_1_p2->set_weight(70.0);


### PR DESCRIPTION
The SceneSynchronizerDebugger was refactored to allow fetching ALL the errors generated by the NetworkSynchronizer at any point by any class.
Removes the debugger singleton, so now it's possible to run both the client and the server on the same process and correctly forward the logs to the right debugger.