### PR TITLE
Add support to scheduled procedure

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -103,6 +103,7 @@ set(NS_SRC_FILES
 	${NS_ROOT}/core/bitcasts.h
 	${NS_ROOT}/core/core.h
 	${NS_ROOT}/core/core.cpp
+	${NS_ROOT}/core/scheduled_procedure.h
 	${NS_ROOT}/core/data_buffer.h
 	${NS_ROOT}/core/data_buffer.cpp
 	${NS_ROOT}/core/ensure.h

--- a/core/core.cpp
+++ b/core/core.cpp
@@ -9,11 +9,11 @@ std::string operator+(const char *p_chr, const std::string &p_str) {
 }
 
 NS_NAMESPACE_BEGIN
-
 const FrameIndex FrameIndex::NONE = FrameIndex{ { std::numeric_limits<std::uint32_t>::max() } };
 const SyncGroupId SyncGroupId::NONE = SyncGroupId{ { std::numeric_limits<std::uint32_t>::max() } };
 const SyncGroupId SyncGroupId::GLOBAL = SyncGroupId{ { 0 } };
 const VarId VarId::NONE = VarId{ { std::numeric_limits<std::uint8_t>::max() } };
+const ScheduledProcedureId ScheduledProcedureId::NONE = ScheduledProcedureId{ { std::numeric_limits<std::uint8_t>::max() } };
 const ObjectLocalId ObjectLocalId::NONE = ObjectLocalId{ { std::numeric_limits<uint32_t>::max() } };
 const ObjectNetId ObjectNetId::NONE = ObjectNetId{ { std::numeric_limits<std::uint16_t>::max() } };
 const ObjectHandle ObjectHandle::NONE = ObjectHandle{ { 0 } };

--- a/core/core.cpp
+++ b/core/core.cpp
@@ -9,6 +9,7 @@ std::string operator+(const char *p_chr, const std::string &p_str) {
 }
 
 NS_NAMESPACE_BEGIN
+const GlobalFrameIndex GlobalFrameIndex::NONE = GlobalFrameIndex{ { std::numeric_limits<std::uint32_t>::max() } };
 const FrameIndex FrameIndex::NONE = FrameIndex{ { std::numeric_limits<std::uint32_t>::max() } };
 const SyncGroupId SyncGroupId::NONE = SyncGroupId{ { std::numeric_limits<std::uint32_t>::max() } };
 const SyncGroupId SyncGroupId::GLOBAL = SyncGroupId{ { 0 } };

--- a/core/core.h
+++ b/core/core.h
@@ -74,6 +74,8 @@ enum PrintMessageType : std::uint8_t {
 	ERROR = 3,
 };
 
+
+
 std::string get_log_level_txt(NS::PrintMessageType p_level);
 
 template <typename T, typename TheIdType>
@@ -127,6 +129,9 @@ struct SyncGroupId : public IdMaker<SyncGroupId, std::uint32_t> {
 struct VarId : public IdMaker<VarId, std::uint8_t> {
 	static const VarId NONE;
 };
+struct ScheduledProcedureId : public IdMaker<ScheduledProcedureId, std::uint8_t> {
+	static const ScheduledProcedureId NONE;
+};
 struct ObjectNetId : public IdMaker<ObjectNetId, std::uint16_t> {
 	static const ObjectNetId NONE;
 };
@@ -137,9 +142,17 @@ struct ObjectHandle : public IdMaker<ObjectHandle, std::intptr_t> {
 	static const ObjectHandle NONE;
 };
 
+enum class ScheduledProcedurePhase : std::uint8_t {
+	COLLECTING_ARGUMENTS = 0,
+	RECEIVED = 1,
+	EXECUTING = 2,
+};
+
 template <typename T>
 constexpr const T sign(const T m_v) {
 	return m_v == 0 ? 0.0f : (m_v < 0 ? -1.0f : +1.0f);
 }
+
+#define NS_ScheduledProcedureFunc std::function<void(const class SynchronizerManager &p_synchronizer_manager, NS::ObjectHandle p_app_object_handle, ScheduledProcedurePhase p_phase, NS::DataBuffer& p_buffer)>
 
 NS_NAMESPACE_END

--- a/core/core.h
+++ b/core/core.h
@@ -146,8 +146,11 @@ struct ObjectHandle : public IdMaker<ObjectHandle, std::intptr_t> {
 };
 
 enum class ScheduledProcedurePhase : std::uint8_t {
+	/// The procedure is called with in this phase only on the server when collecting the arguments.
 	COLLECTING_ARGUMENTS = 0,
+	/// This is executed on the client when the procedure is received. In some case this is not executed, so don't count on this too much.
 	RECEIVED = 1,
+	/// The scheduled procedure time is over and the execute is triggered. Here the procedure can do its normal job.
 	EXECUTING = 2,
 };
 

--- a/core/core.h
+++ b/core/core.h
@@ -118,6 +118,9 @@ struct IdMaker {
 	}
 };
 
+struct GlobalFrameIndex : public IdMaker<GlobalFrameIndex, std::uint32_t> {
+	static const GlobalFrameIndex NONE;
+};
 struct FrameIndex : public IdMaker<FrameIndex, std::uint32_t> {
 	static const FrameIndex NONE;
 };

--- a/core/net_utilities.cpp
+++ b/core/net_utilities.cpp
@@ -94,6 +94,7 @@ void NS::SyncGroup::mark_changes_as_notified(bool p_is_partial_update, const std
 		for (const std::size_t index : p_partial_update_simulated_objects_info_indices) {
 			simulated_sync_objects[index].change.unknown = false;
 			simulated_sync_objects[index].change.vars.clear();
+			simulated_sync_objects[index].change.changed_scheduled_procedures.clear();
 		}
 	} else {
 		// When it isn't a partial update this array is always empty
@@ -103,6 +104,7 @@ void NS::SyncGroup::mark_changes_as_notified(bool p_is_partial_update, const std
 		for (auto &sso : simulated_sync_objects) {
 			sso.change.unknown = false;
 			sso.change.vars.clear();
+			sso.change.changed_scheduled_procedures.clear();
 		}
 	}
 
@@ -340,12 +342,12 @@ void NS::SyncGroup::notify_variable_changed(ObjectData *p_object_data, VarId p_v
 	}
 }
 
-void NS::SyncGroup::notify_procedure_state_update(ObjectData &p_object_data, ScheduledProcedureId p_scheduled_procedure_id, GlobalFrameIndex p_frame_index, DataBuffer &p_data) {
+void NS::SyncGroup::notify_scheduled_procedure_changed(ObjectData &p_object_data, ScheduledProcedureId p_scheduled_procedure_id) {
 	const std::size_t index = find_simulated(p_object_data);
 	if (index != VecFunc::index_none()) {
-		VecFunc::insert_or_update(
-				simulated_sync_objects[index].change.procedures_with_status_update,
-				ScheduledProcedureExeInfo(p_object_data.get_net_id(), p_scheduled_procedure_id, p_frame_index, p_data));
+		VecFunc::insert_unique(
+				simulated_sync_objects[index].change.changed_scheduled_procedures,
+				ScheduledProcedureHandle(p_object_data.get_net_id(), p_scheduled_procedure_id));
 	}
 }
 

--- a/core/net_utilities.cpp
+++ b/core/net_utilities.cpp
@@ -340,6 +340,15 @@ void NS::SyncGroup::notify_variable_changed(ObjectData *p_object_data, VarId p_v
 	}
 }
 
+void NS::SyncGroup::notify_procedure_state_update(ObjectData &p_object_data, ScheduledProcedureId p_scheduled_procedure_id, GlobalFrameIndex p_frame_index, DataBuffer &p_data) {
+	const std::size_t index = find_simulated(p_object_data);
+	if (index != VecFunc::index_none()) {
+		VecFunc::insert_or_update(
+				simulated_sync_objects[index].change.procedures_with_status_update,
+				ScheduledProcedureExeInfo(p_object_data.get_net_id(), p_scheduled_procedure_id, p_frame_index, p_data));
+	}
+}
+
 void NS::SyncGroup::set_simulated_partial_update_timespan_seconds(const ObjectData &p_object_data, bool p_partial_update_enabled, float p_update_timespan) {
 	const std::size_t index = find_simulated(p_object_data);
 	if (index != VecFunc::index_none()) {

--- a/core/net_utilities.h
+++ b/core/net_utilities.h
@@ -2,6 +2,7 @@
 
 #include "core.h"
 #include "processor.h"
+#include "scheduled_procedure.h"
 #include "var_data.h"
 
 #include <algorithm>
@@ -134,6 +135,16 @@ bool insert_unique(std::vector<V> &r_vec, const T &p_val) {
 		return true;
 	}
 	return false;
+}
+
+template <class V, typename T>
+void insert_or_update(std::vector<V> &r_vec, const T &p_val) {
+	auto it = find(r_vec, p_val);
+	if (it == r_vec.end()) {
+		r_vec.push_back(p_val);
+	} else {
+		return *it = p_val;
+	}
 }
 
 template <class V, typename T>
@@ -298,6 +309,7 @@ public:
 		bool unknown = false;
 		std::vector<VarId> vars;
 		bool controlling_peer_changed = false;
+		std::vector<ScheduledProcedureExeInfo> procedures_with_status_update;
 	};
 
 	struct SimulatedObjectInfo {
@@ -446,6 +458,8 @@ public:
 
 	void notify_new_variable(struct ObjectData *p_object_data, VarId p_var_id);
 	void notify_variable_changed(struct ObjectData *p_object_data, VarId p_var_id);
+
+	void notify_procedure_state_update(ObjectData &p_object_data, ScheduledProcedureId p_scheduled_procedure_id, GlobalFrameIndex p_frame_index = GlobalFrameIndex{ 0 }, class DataBuffer &p_data);
 
 	void set_simulated_partial_update_timespan_seconds(const struct ObjectData &p_object_data, bool p_partial_update_enabled, float p_update_timespan);
 	bool is_simulated_partial_updating(const struct ObjectData &p_object_data) const;

--- a/core/net_utilities.h
+++ b/core/net_utilities.h
@@ -171,7 +171,7 @@ void insert_at_position_expand(std::vector<V> &r_vec, std::size_t p_index, const
 }
 
 
-// Insert the value in a sorted vector. Returns true if the value was inserted, returns false if the element was already into the array.
+// Insert the value in a sorted vector.
 template <class V, typename T>
 void insert_sorted(std::vector<V> &r_vec, const T &p_value) {
 	auto it = std::lower_bound(r_vec.begin(), r_vec.end(), p_value);
@@ -309,7 +309,7 @@ public:
 		bool unknown = false;
 		std::vector<VarId> vars;
 		bool controlling_peer_changed = false;
-		std::vector<ScheduledProcedureExeInfo> procedures_with_status_update;
+		std::vector<ScheduledProcedureHandle> changed_scheduled_procedures;
 	};
 
 	struct SimulatedObjectInfo {
@@ -459,7 +459,7 @@ public:
 	void notify_new_variable(struct ObjectData *p_object_data, VarId p_var_id);
 	void notify_variable_changed(struct ObjectData *p_object_data, VarId p_var_id);
 
-	void notify_procedure_state_update(ObjectData &p_object_data, ScheduledProcedureId p_scheduled_procedure_id, GlobalFrameIndex p_frame_index = GlobalFrameIndex{ 0 }, class DataBuffer &p_data);
+	void notify_scheduled_procedure_changed(struct ObjectData &p_object_data, ScheduledProcedureId p_scheduled_procedure_id);
 
 	void set_simulated_partial_update_timespan_seconds(const struct ObjectData &p_object_data, bool p_partial_update_enabled, float p_update_timespan);
 	bool is_simulated_partial_updating(const struct ObjectData &p_object_data) const;

--- a/core/network_codec.cpp
+++ b/core/network_codec.cpp
@@ -5,13 +5,20 @@
 #include "var_data.h"
 
 NS_NAMESPACE_BEGIN
-
 void encode_variable(bool val, DataBuffer &r_buffer) {
 	r_buffer.add_bool(val);
 }
 
 void decode_variable(bool &val, DataBuffer &p_buffer) {
 	val = p_buffer.read_bool();
+}
+
+void encode_variable(std::uint8_t val, DataBuffer &r_buffer) {
+	r_buffer.add(val);
+}
+
+void decode_variable(std::uint8_t &val, DataBuffer &p_buffer) {
+	p_buffer.read(val);
 }
 
 void encode_variable(int val, DataBuffer &r_buffer) {
@@ -22,6 +29,30 @@ void encode_variable(int val, DataBuffer &r_buffer) {
 void decode_variable(int &val, DataBuffer &p_buffer) {
 	// TODO optimize
 	val = int(p_buffer.read_int(DataBuffer::COMPRESSION_LEVEL_0));
+}
+
+void encode_variable(ObjectNetId val, DataBuffer &r_buffer) {
+	r_buffer.add(val.id);
+}
+
+void decode_variable(ObjectNetId &val, DataBuffer &p_buffer) {
+	p_buffer.read(val.id);
+}
+
+void encode_variable(FrameIndex val, DataBuffer &r_buffer) {
+	r_buffer.add(val.id);
+}
+
+void decode_variable(FrameIndex &val, DataBuffer &p_buffer) {
+	p_buffer.read(val.id);
+}
+
+void encode_variable(ScheduledProcedureId val, DataBuffer &r_buffer) {
+	r_buffer.add(val.id);
+}
+
+void decode_variable(ScheduledProcedureId &val, DataBuffer &p_buffer) {
+	p_buffer.read(val.id);
 }
 
 void encode_variable(float val, DataBuffer &r_buffer) {

--- a/core/network_codec.cpp
+++ b/core/network_codec.cpp
@@ -47,6 +47,14 @@ void decode_variable(FrameIndex &val, DataBuffer &p_buffer) {
 	p_buffer.read(val.id);
 }
 
+void encode_variable(GlobalFrameIndex val, DataBuffer &r_buffer) {
+	r_buffer.add(val.id);
+}
+
+void decode_variable(GlobalFrameIndex &val, DataBuffer &p_buffer) {
+	p_buffer.read(val.id);
+}
+
 void encode_variable(ScheduledProcedureId val, DataBuffer &r_buffer) {
 	r_buffer.add(val.id);
 }

--- a/core/network_codec.h
+++ b/core/network_codec.h
@@ -20,6 +20,9 @@ void decode_variable(ObjectNetId &val, DataBuffer &p_buffer);
 void encode_variable(FrameIndex val, DataBuffer &r_buffer);
 void decode_variable(FrameIndex &val, DataBuffer &p_buffer);
 
+void encode_variable(GlobalFrameIndex val, DataBuffer &r_buffer);
+void decode_variable(GlobalFrameIndex &val, DataBuffer &p_buffer);
+
 void encode_variable(ScheduledProcedureId val, DataBuffer &r_buffer);
 void decode_variable(ScheduledProcedureId &val, DataBuffer &p_buffer);
 

--- a/core/network_codec.h
+++ b/core/network_codec.h
@@ -8,8 +8,20 @@ NS_NAMESPACE_BEGIN
 void encode_variable(bool val, class DataBuffer &r_buffer);
 void decode_variable(bool &val, DataBuffer &p_buffer);
 
+void encode_variable(std::uint8_t val, DataBuffer &r_buffer);
+void decode_variable(std::uint8_t &val, DataBuffer &p_buffer);
+
 void encode_variable(int val, DataBuffer &r_buffer);
 void decode_variable(int &val, DataBuffer &p_buffer);
+
+void encode_variable(ObjectNetId val, DataBuffer &r_buffer);
+void decode_variable(ObjectNetId &val, DataBuffer &p_buffer);
+
+void encode_variable(FrameIndex val, DataBuffer &r_buffer);
+void decode_variable(FrameIndex &val, DataBuffer &p_buffer);
+
+void encode_variable(ScheduledProcedureId val, DataBuffer &r_buffer);
+void decode_variable(ScheduledProcedureId &val, DataBuffer &p_buffer);
 
 void encode_variable(float val, DataBuffer &r_buffer);
 void decode_variable(float &val, DataBuffer &r_buffer);

--- a/core/object_data.cpp
+++ b/core/object_data.cpp
@@ -216,6 +216,11 @@ void ObjectData::scheduled_procedure_start(ScheduledProcedureId p_id, GlobalFram
 }
 
 void ObjectData::scheduled_procedure_pause(ScheduledProcedureId p_id, GlobalFrameIndex p_current_frame) {
+	scheduled_procedure_pause(p_id, scheduled_procedures[p_id.id].execute_frame, p_current_frame);
+}
+
+void ObjectData::scheduled_procedure_pause(ScheduledProcedureId p_id, GlobalFrameIndex p_executes_at_frame, GlobalFrameIndex p_current_frame) {
+	scheduled_procedures[p_id.id].execute_frame = p_executes_at_frame;
 	scheduled_procedures[p_id.id].paused_frame = p_current_frame;
 	storage.notify_scheduled_procedure_updated(*this, p_id, false);
 }

--- a/core/object_data.cpp
+++ b/core/object_data.cpp
@@ -174,6 +174,10 @@ bool ObjectData::scheduled_procedure_exist(ScheduledProcedureId p_id) const {
 
 void ObjectData::scheduled_procedure_remove(ScheduledProcedureId p_id) {
 	scheduled_procedures[p_id.id].func = nullptr;
+	scheduled_procedures[p_id.id].execute_frame = GlobalFrameIndex{ 0 };
+	scheduled_procedures[p_id.id].paused_frame = GlobalFrameIndex{ 0 };
+	scheduled_procedures[p_id.id].args = DataBuffer();
+	storage.notify_scheduled_procedure_updated(*this, p_id, false);
 }
 
 

--- a/core/object_data.cpp
+++ b/core/object_data.cpp
@@ -226,6 +226,11 @@ void ObjectData::scheduled_procedure_stop(ScheduledProcedureId p_id) {
 	storage.notify_scheduled_procedure_updated(*this, p_id, false);
 }
 
+bool ObjectData::scheduled_procedure_is_inprogress(ScheduledProcedureId p_id) const {
+	return scheduled_procedures[p_id.id].paused_frame == GlobalFrameIndex{ 0 }
+			&& scheduled_procedures[p_id.id].execute_frame > GlobalFrameIndex{ 0 };
+}
+
 bool ObjectData::scheduled_procedure_is_paused(ScheduledProcedureId p_id) const {
 	return scheduled_procedures[p_id.id].paused_frame > GlobalFrameIndex{ 0 };
 }

--- a/core/object_data.h
+++ b/core/object_data.h
@@ -88,7 +88,9 @@ public:
 	/// The sync variables of this node. The order of this vector matters
 	/// because the index is the `VarId`.
 	std::vector<VarDescriptor> vars;
-	NS::Processor<float> functions[PROCESS_PHASE_COUNT];
+	Processor<float> functions[PROCESS_PHASE_COUNT];
+
+	std::vector<NS_ScheduledProcedureFunc> scheduled_procedure_funcs;
 
 	std::function<void(DataBuffer & /*out_buffer*/, float /*update_rate*/)> func_trickled_collect;
 	std::function<void(float /*delta*/, float /*interpolation_alpha*/, DataBuffer & /*past_buffer*/, DataBuffer & /*future_buffer*/)> func_trickled_apply;

--- a/core/object_data.h
+++ b/core/object_data.h
@@ -137,7 +137,7 @@ public:
 	void scheduled_procedure_set_args(ScheduledProcedureId p_id, const DataBuffer &p_args);
 
 	void scheduled_procedure_execute(ScheduledProcedureId p_id, ScheduledProcedurePhase p_phase, const SynchronizerManager &p_sync_manager, SceneSynchronizerDebugger &p_debugger);
-	
+
 	/// Starts a procedure. Notice this function calls the procedure to initialize the args DataBuffer.
 	void scheduled_procedure_start(ScheduledProcedureId p_id, GlobalFrameIndex p_executes_at_frame);
 	/// Pause the procedure.
@@ -152,6 +152,10 @@ public:
 
 	GlobalFrameIndex scheduled_procedure_get_execute_frame(ScheduledProcedureId p_id) const;
 	const DataBuffer &scheduled_procedure_get_args(ScheduledProcedureId p_id) const;
+
+	const std::vector<ScheduledProcedureInfo> &get_scheduled_procedures() const {
+		return scheduled_procedures;
+	}
 };
 
 NS_NAMESPACE_END

--- a/core/object_data.h
+++ b/core/object_data.h
@@ -142,6 +142,7 @@ public:
 	void scheduled_procedure_start(ScheduledProcedureId p_id, GlobalFrameIndex p_executes_at_frame);
 	/// Pause the procedure.
 	void scheduled_procedure_pause(ScheduledProcedureId p_id, GlobalFrameIndex p_current_frame);
+	void scheduled_procedure_pause(ScheduledProcedureId p_id, GlobalFrameIndex p_executes_at_frame, GlobalFrameIndex p_current_frame);
 	/// Stop the procedure.
 	void scheduled_procedure_stop(ScheduledProcedureId p_id);
 

--- a/core/object_data.h
+++ b/core/object_data.h
@@ -146,6 +146,7 @@ public:
 	void scheduled_procedure_stop(ScheduledProcedureId p_id);
 
 	/// Returns true if the procedure is paused.
+	bool scheduled_procedure_is_inprogress(ScheduledProcedureId p_id) const;
 	bool scheduled_procedure_is_paused(ScheduledProcedureId p_id) const;
 	/// Returns the remaining frames of this procedure according to its status (Playing, Paused, Stop)
 	std::uint32_t scheduled_procedure_remaining_frames(ScheduledProcedureId p_id, GlobalFrameIndex p_current_frame) const;

--- a/core/object_data_storage.cpp
+++ b/core/object_data_storage.cpp
@@ -67,6 +67,13 @@ void ObjectDataStorage::deallocate_object_data(ObjectData &p_object_data) {
 	// Remove from unnamed_objects_data if set
 	VecFunc::remove_unordered(unnamed_objects_data, &p_object_data);
 
+	// Clear the active procedures.
+	for (int i = int(sorted_active_scheduled_procedures.size()) - 1; i >= 0; i--) {
+		if (sorted_active_scheduled_procedures[i].get_object_net_id() == p_object_data.get_net_id()) {
+			VecFunc::remove_at(sorted_active_scheduled_procedures, i);
+		}
+	}
+
 	delete (&p_object_data);
 
 	free_local_indices.push_back(local_id);
@@ -151,7 +158,7 @@ NS::ObjectData *ObjectDataStorage::get_object_data(ObjectLocalId p_handle, bool 
 	return objects_data[p_handle.id];
 }
 
-const NS::ObjectData *ObjectDataStorage::get_object_data(ObjectLocalId p_handle, bool p_expected) const {
+const ObjectData *ObjectDataStorage::get_object_data(ObjectLocalId p_handle, bool p_expected) const {
 	if (p_expected) {
 		NS_ENSURE_V_MSG(p_handle.id < objects_data.size(), nullptr, "The ObjectData with LocalID `" + std::to_string(p_handle.id) + "` was not found.");
 	} else {
@@ -233,6 +240,16 @@ void ObjectDataStorage::notify_object_name_unnamed_changed(ObjectData &p_object)
 		VecFunc::insert_unique(unnamed_objects_data, &p_object);
 	} else {
 		VecFunc::remove_unordered(unnamed_objects_data, &p_object);
+	}
+}
+
+void ObjectDataStorage::notify_scheduled_procedure_updated(ObjectData &p_object, const ScheduledProcedureId p_procedure_id, bool p_active) {
+	if (p_active) {
+		if (!VecFunc::has(sorted_active_scheduled_procedures, ScheduledProcedureHandle(p_object.get_net_id(), p_procedure_id))) {
+			VecFunc::insert_sorted(sorted_active_scheduled_procedures, ScheduledProcedureHandle(p_object.get_net_id(), p_procedure_id));
+		}
+	} else {
+		VecFunc::remove(sorted_active_scheduled_procedures, ScheduledProcedureHandle(p_object.get_net_id(), p_procedure_id));
 	}
 }
 

--- a/core/object_data_storage.h
+++ b/core/object_data_storage.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "core.h"
+#include "scheduled_procedure.h"
+
 #include <map>
 #include <vector>
 
@@ -19,6 +21,8 @@ class ObjectDataStorage {
 	std::map<int, std::vector<ObjectData *>> objects_data_controlled_by_peers;
 
 	std::vector<ObjectData *> unnamed_objects_data;
+
+	std::vector<ScheduledProcedureHandle> sorted_active_scheduled_procedures;
 
 public:
 	ObjectDataStorage(class SceneSynchronizerBase &p_sync);
@@ -53,6 +57,12 @@ public:
 	void notify_set_controlled_by_peer(int p_old_peer, ObjectData &p_object);
 
 	void notify_object_name_unnamed_changed(ObjectData &p_object);
+
+	void notify_scheduled_procedure_updated(ObjectData &p_object, const ScheduledProcedureId p_procedure_id, bool p_active);
+
+	const std::vector<ScheduledProcedureHandle> &get_sorted_active_scheduled_procedures() const {
+		return sorted_active_scheduled_procedures;
+	}
 };
 
 NS_NAMESPACE_END

--- a/core/peer_networked_controller.cpp
+++ b/core/peer_networked_controller.cpp
@@ -1604,7 +1604,7 @@ void DollController::copy_controlled_objects_snapshot(
 				biggest_id = object_data->get_net_id();
 			}
 		}
-		snap->data.object_vars.resize(biggest_id.id + 1);
+		snap->data.objects.resize(biggest_id.id + 1);
 	}
 
 	snap->data.simulated_objects.clear();
@@ -1621,12 +1621,12 @@ void DollController::copy_controlled_objects_snapshot(
 
 		snap->data.simulated_objects.push_back(object_data->get_net_id());
 
-		snap->data.object_vars[object_data->get_net_id().id].clear();
+		snap->data.objects[object_data->get_net_id().id].vars.clear();
 		for (const std::optional<VarData> &nav : *vars) {
 			if (nav.has_value()) {
-				snap->data.object_vars[object_data->get_net_id().id].push_back(VarData::make_copy(nav.value()));
+				snap->data.objects[object_data->get_net_id().id].vars.push_back(VarData::make_copy(nav.value()));
 			} else {
-				snap->data.object_vars[object_data->get_net_id().id].push_back(std::optional<VarData>());
+				snap->data.objects[object_data->get_net_id().id].vars.push_back(std::optional<VarData>());
 			}
 		}
 	}

--- a/core/peer_networked_controller.cpp
+++ b/core/peer_networked_controller.cpp
@@ -91,6 +91,11 @@ int PeerNetworkedController::get_max_redundant_inputs() const {
 	return scene_synchronizer ? scene_synchronizer->get_max_redundant_inputs() : 0;
 }
 
+FrameIndex PeerNetworkedController::get_checked_frame_index() const {
+	NS_ENSURE_V(controller, FrameIndex::NONE);
+	return controller->get_checked_frame_index();
+}
+
 FrameIndex PeerNetworkedController::get_current_frame_index() const {
 	NS_ENSURE_V(controller, FrameIndex::NONE);
 	return controller->get_current_frame_index();
@@ -580,6 +585,10 @@ void RemotelyControlledController::on_peer_update(bool p_peer_enabled) {
 	// Client inputs reset.
 	ghost_input_count = 0;
 	frames_input.clear();
+}
+
+FrameIndex RemotelyControlledController::get_checked_frame_index() const {
+	return current_input_buffer_id == FrameIndex::NONE ? FrameIndex{ 0 } : current_input_buffer_id - 1;
 }
 
 FrameIndex RemotelyControlledController::get_current_frame_index() const {
@@ -1174,6 +1183,10 @@ void PlayerController::on_state_validated(FrameIndex p_frame_index, bool p_detec
 
 void PlayerController::on_app_process_end(float p_delta_seconds) {
 	send_frame_input_buffer_to_server();
+}
+
+FrameIndex PlayerController::get_checked_frame_index() const {
+	return FrameIndex{ frames_input.size() > 0 ? FrameIndex{ frames_input.front().id.id - 1 } : current_input_id };
 }
 
 FrameIndex PlayerController::get_current_frame_index() const {
@@ -1961,6 +1974,10 @@ void NoNetController::process(float p_delta) {
 	peer_controller->controllable_process(p_delta, peer_controller->get_inputs_buffer_mut());
 	peer_controller->get_debugger().databuffer_operation_end_record();
 	frame_id += 1;
+}
+
+FrameIndex NoNetController::get_checked_frame_index() const {
+	return frame_id == FrameIndex::NONE ? FrameIndex{ 0 } : frame_id - 1;
 }
 
 FrameIndex NoNetController::get_current_frame_index() const {

--- a/core/peer_networked_controller.h
+++ b/core/peer_networked_controller.h
@@ -163,6 +163,7 @@ public:
 
 	void controllable_collect_input(float p_delta, DataBuffer &r_data_buffer);
 	bool controllable_are_inputs_different(DataBuffer &p_data_buffer_A, DataBuffer &p_data_buffer_B);
+	bool is_ready_to_process();
 	void controllable_process(float p_delta, DataBuffer &p_data_buffer);
 
 	void notify_receive_inputs(const std::vector<std::uint8_t> &p_data);

--- a/core/peer_networked_controller.h
+++ b/core/peer_networked_controller.h
@@ -107,6 +107,7 @@ public: // ---------------------------------------------------------------- APIs
 
 	int get_max_redundant_inputs() const;
 
+	FrameIndex get_checked_frame_index() const;
 	FrameIndex get_current_frame_index() const;
 
 	const DataBuffer &get_inputs_buffer() const {
@@ -203,6 +204,7 @@ struct Controller {
 	virtual void ready() {
 	}
 
+	virtual FrameIndex get_checked_frame_index() const = 0;
 	virtual FrameIndex get_current_frame_index() const = 0;
 	virtual void process(float p_delta) = 0;
 
@@ -225,6 +227,7 @@ public:
 
 	virtual void on_peer_update(bool p_peer_enabled);
 
+	virtual FrameIndex get_checked_frame_index() const override;
 	virtual FrameIndex get_current_frame_index() const override;
 	virtual int get_inputs_count() const;
 	FrameIndex last_known_frame_index() const;
@@ -260,7 +263,7 @@ struct AutonomousServerController final : public ServerController {
 	PHandler event_handler_on_app_process_end = NullPHandler;
 
 	std::vector<std::uint8_t> cached_packet_data;
-	
+
 	AutonomousServerController(
 			PeerNetworkedController *p_node);
 	~AutonomousServerController();
@@ -294,6 +297,7 @@ struct PlayerController final : public Controller {
 	int count_frames_after(FrameIndex p_frame_index) const;
 	FrameIndex last_known_frame_index() const;
 	FrameIndex get_stored_frame_index(int p_i) const;
+	virtual FrameIndex get_checked_frame_index() const override;
 	virtual FrameIndex get_current_frame_index() const override;
 
 	void on_rewind_frame_begin(FrameIndex p_frame_index, int p_rewinding_index, int p_rewinding_frame_count);
@@ -420,6 +424,7 @@ struct NoNetController : public Controller {
 	NoNetController(PeerNetworkedController *p_node);
 
 	virtual void process(float p_delta) override;
+	virtual FrameIndex get_checked_frame_index() const override;
 	virtual FrameIndex get_current_frame_index() const override;
 };
 

--- a/core/scheduled_procedure.h
+++ b/core/scheduled_procedure.h
@@ -1,0 +1,25 @@
+﻿#pragma once
+
+#include "core.h"
+#include "data_buffer.h"
+
+NS_NAMESPACE_BEGIN
+struct ScheduledProcedureInfo {
+	ObjectLocalId object_local_id;
+	ScheduledProcedureId procedure_id;
+	FrameIndex execute_at_frame;
+	DataBuffer arguments;
+
+	bool operator<(const ScheduledProcedureInfo &p_other) const {
+		return procedure_id < p_other.procedure_id;
+	}
+
+	bool operator==(const ScheduledProcedureInfo &p_other) const {
+		return object_local_id == p_other.object_local_id
+				&& procedure_id == p_other.procedure_id
+				&& execute_at_frame == p_other.execute_at_frame
+				&& arguments == p_other.arguments;
+	}
+};
+
+NS_NAMESPACE_END

--- a/core/scheduled_procedure.h
+++ b/core/scheduled_procedure.h
@@ -4,21 +4,54 @@
 #include "data_buffer.h"
 
 NS_NAMESPACE_BEGIN
-struct ScheduledProcedureInfo {
-	ObjectLocalId object_local_id;
-	ScheduledProcedureId procedure_id;
-	FrameIndex execute_at_frame;
+struct ScheduledProcedureExeInfo {
+	union {
+		std::uint32_t unique_id;
+
+		struct {
+			ObjectNetId object_net_id;
+			ScheduledProcedureId procedure_id;
+			ScheduledProcedureId _not_used;
+		};
+	} procedure_info_id;
+
+	GlobalFrameIndex execute_at_frame;
 	DataBuffer arguments;
 
-	bool operator<(const ScheduledProcedureInfo &p_other) const {
-		return procedure_id < p_other.procedure_id;
+	ScheduledProcedureExeInfo(
+			ObjectNetId p_object_local_id,
+			ScheduledProcedureId p_procedure_id,
+			GlobalFrameIndex p_execute_at_frame,
+			const DataBuffer &p_arguments = DataBuffer()) :
+		execute_at_frame(p_execute_at_frame),
+		arguments(p_arguments) {
+		static_assert(sizeof(procedure_info_id) == sizeof(std::uint32_t));
+		procedure_info_id.object_net_id = p_object_local_id;
+		procedure_info_id.procedure_id = p_procedure_id;
+		procedure_info_id._not_used = ScheduledProcedureId::NONE;
 	}
 
-	bool operator==(const ScheduledProcedureInfo &p_other) const {
-		return object_local_id == p_other.object_local_id
-				&& procedure_id == p_other.procedure_id
+	bool operator<(const ScheduledProcedureExeInfo &p_other) const {
+		return procedure_info_id.unique_id < p_other.procedure_info_id.unique_id;
+	}
+
+	bool operator==(const ScheduledProcedureExeInfo &p_other) const {
+		return procedure_info_id.unique_id == p_other.procedure_info_id.unique_id;
+	}
+
+	bool equals(const ScheduledProcedureExeInfo &p_other) const {
+		return
+				procedure_info_id.unique_id == p_other.procedure_info_id.unique_id
 				&& execute_at_frame == p_other.execute_at_frame
 				&& arguments == p_other.arguments;
+	}
+
+	ObjectNetId get_object_net_id() const {
+		return procedure_info_id.object_net_id;
+	}
+
+	ScheduledProcedureId get_scheduled_procedure_id() const {
+		return procedure_info_id.procedure_id;
 	}
 };
 

--- a/core/scheduled_procedure.h
+++ b/core/scheduled_procedure.h
@@ -1,57 +1,37 @@
 ﻿#pragma once
 
 #include "core.h"
-#include "data_buffer.h"
 
 NS_NAMESPACE_BEGIN
-struct ScheduledProcedureExeInfo {
-	union {
-		std::uint32_t unique_id;
+struct ScheduledProcedureHandle {
+	ObjectNetId object_net_id;
+	ScheduledProcedureId procedure_id;
 
-		struct {
-			ObjectNetId object_net_id;
-			ScheduledProcedureId procedure_id;
-			ScheduledProcedureId _not_used;
-		};
-	} procedure_info_id;
-
-	GlobalFrameIndex execute_at_frame;
-	DataBuffer arguments;
-
-	ScheduledProcedureExeInfo(
+	ScheduledProcedureHandle(
 			ObjectNetId p_object_local_id,
-			ScheduledProcedureId p_procedure_id,
-			GlobalFrameIndex p_execute_at_frame,
-			const DataBuffer &p_arguments = DataBuffer()) :
-		execute_at_frame(p_execute_at_frame),
-		arguments(p_arguments) {
-		static_assert(sizeof(procedure_info_id) == sizeof(std::uint32_t));
-		procedure_info_id.object_net_id = p_object_local_id;
-		procedure_info_id.procedure_id = p_procedure_id;
-		procedure_info_id._not_used = ScheduledProcedureId::NONE;
+			ScheduledProcedureId p_procedure_id) {
+		object_net_id = p_object_local_id;
+		procedure_id = p_procedure_id;
 	}
 
-	bool operator<(const ScheduledProcedureExeInfo &p_other) const {
-		return procedure_info_id.unique_id < p_other.procedure_info_id.unique_id;
+	bool operator<(const ScheduledProcedureHandle &p_other) const {
+		if (get_object_net_id() == p_other.get_object_net_id()) {
+			return get_scheduled_procedure_id() < p_other.get_scheduled_procedure_id();
+		} else {
+			return get_object_net_id() < p_other.get_object_net_id();
+		}
 	}
 
-	bool operator==(const ScheduledProcedureExeInfo &p_other) const {
-		return procedure_info_id.unique_id == p_other.procedure_info_id.unique_id;
-	}
-
-	bool equals(const ScheduledProcedureExeInfo &p_other) const {
-		return
-				procedure_info_id.unique_id == p_other.procedure_info_id.unique_id
-				&& execute_at_frame == p_other.execute_at_frame
-				&& arguments == p_other.arguments;
+	bool operator==(const ScheduledProcedureHandle &p_other) const {
+		return object_net_id == p_other.object_net_id && procedure_id == p_other.procedure_id;
 	}
 
 	ObjectNetId get_object_net_id() const {
-		return procedure_info_id.object_net_id;
+		return object_net_id;
 	}
 
 	ScheduledProcedureId get_scheduled_procedure_id() const {
-		return procedure_info_id.procedure_id;
+		return procedure_id;
 	}
 };
 

--- a/core/snapshot.cpp
+++ b/core/snapshot.cpp
@@ -111,6 +111,7 @@ NS::Snapshot NS::Snapshot::make_copy(const Snapshot &p_other) {
 
 void NS::Snapshot::copy(const Snapshot &p_other) {
 	input_id = p_other.input_id;
+	global_frame_index = p_other.global_frame_index;
 	simulated_objects = p_other.simulated_objects;
 	peers_frames_index = p_other.peers_frames_index;
 	object_vars.resize(p_other.object_vars.size());
@@ -144,6 +145,17 @@ bool NS::Snapshot::compare(
 #ifdef NS_DEBUG_ENABLED
 	bool is_equal = true;
 #endif
+
+	if (p_snap_A.global_frame_index != p_snap_B.global_frame_index) {
+		if (r_differences_info) {
+			r_differences_info->push_back("Difference detected: global frame index in snapshot A `" + std::to_string(p_snap_A.global_frame_index.id) + "` is different in snap B `" + std::to_string(p_snap_B.global_frame_index.id) + "`.");
+		}
+#ifdef NS_DEBUG_ENABLED
+		is_equal = false;
+#else
+		return false;
+#endif
+	}
 
 	// Compares the simualated object first.
 	if (p_snap_A.simulated_objects.size() != p_snap_B.simulated_objects.size()) {

--- a/core/snapshot.cpp
+++ b/core/snapshot.cpp
@@ -215,7 +215,7 @@ bool NS::Snapshot::compare(
 #endif
 	} else {
 		for (int i = 0; i < p_snap_A.pending_scheduled_procedures.size(); i++) {
-			if (p_snap_A.pending_scheduled_procedures[i] != p_snap_B.pending_scheduled_procedures[i]) {
+			if (!p_snap_A.pending_scheduled_procedures[i].equals(p_snap_B.pending_scheduled_procedures[i])) {
 				if (r_differences_info) {
 					r_differences_info->push_back("Difference detected: executed_scheduled_procedures at index `" + std::to_string(i) + "` is different.");
 				}

--- a/core/snapshot.cpp
+++ b/core/snapshot.cpp
@@ -126,6 +126,7 @@ void NS::Snapshot::copy(const Snapshot &p_other) {
 	}
 	has_custom_data = p_other.has_custom_data;
 	custom_data.copy(p_other.custom_data);
+	pending_scheduled_procedures = p_other.pending_scheduled_procedures;
 }
 
 bool NS::Snapshot::compare(
@@ -189,6 +190,30 @@ bool NS::Snapshot::compare(
 #else
 		return false;
 #endif
+	}
+
+	if (p_snap_A.pending_scheduled_procedures.size() != p_snap_B.pending_scheduled_procedures.size()) {
+		if (r_differences_info) {
+			r_differences_info->push_back("Difference detected: executed_scheduled_procedures is different.");
+		}
+#ifdef NS_DEBUG_ENABLED
+		is_equal = false;
+#else
+		return false;
+#endif
+	} else {
+		for (int i = 0; i < p_snap_A.pending_scheduled_procedures.size(); i++) {
+			if (p_snap_A.pending_scheduled_procedures[i] != p_snap_B.pending_scheduled_procedures[i]) {
+				if (r_differences_info) {
+					r_differences_info->push_back("Difference detected: executed_scheduled_procedures at index `" + std::to_string(i) + "` is different.");
+				}
+#ifdef NS_DEBUG_ENABLED
+				is_equal = false;
+#else
+		return false;
+#endif
+			}
+		}
 	}
 
 	if (r_no_rewind_recover) {

--- a/core/snapshot.cpp
+++ b/core/snapshot.cpp
@@ -103,6 +103,13 @@ const std::vector<std::optional<NS::VarData>> *NS::Snapshot::get_object_vars(Obj
 	return nullptr;
 }
 
+const std::vector<NS::ScheduledProcedureSnapshot> *NS::Snapshot::get_object_procedures(ObjectNetId p_id) const {
+	if (objects.size() > p_id.id) {
+		return &objects[p_id.id].procedures;
+	}
+	return nullptr;
+}
+
 NS::Snapshot NS::Snapshot::make_copy(const Snapshot &p_other) {
 	Snapshot s;
 	s.copy(p_other);

--- a/core/snapshot.h
+++ b/core/snapshot.h
@@ -2,7 +2,6 @@
 
 #include "core.h"
 #include "object_data.h"
-#include "scheduled_procedure.h"
 #include <map>
 #include <optional>
 
@@ -51,14 +50,30 @@ struct FrameIndexWithMeta {
 	}
 };
 
+struct ScheduledProcedureSnapshot {
+	GlobalFrameIndex execute_frame = GlobalFrameIndex{ 0 };
+	GlobalFrameIndex paused_frame = GlobalFrameIndex{ 0 };
+	DataBuffer args;
+
+	bool operator==(const ScheduledProcedureSnapshot &p_other) const {
+		return execute_frame == p_other.execute_frame
+				&& paused_frame == p_other.paused_frame
+				&& args == p_other.args;
+	}
+};
+
+struct ObjectDataSnapshot {
+	std::vector<std::optional<VarData>> vars;
+	std::vector<ScheduledProcedureSnapshot> procedures;
+};
+
 struct Snapshot {
 	FrameIndex input_id = FrameIndex::NONE;
 	GlobalFrameIndex global_frame_index = GlobalFrameIndex::NONE;
 	std::vector<SimulatedObjectInfo> simulated_objects;
-	/// The Node variables in a particular frame. The order of this vector
+	/// The objects info in a particular frame. The order of this vector
 	/// matters because the index is the `ObjectNetId`.
-	/// The variable array order also matter.
-	std::vector<std::vector<std::optional<VarData>>> object_vars;
+	std::vector<ObjectDataSnapshot> objects;
 
 	/// The executed FrameIndex for the simulating peers.
 	/// NOTE: Due to the nature of the doll simulation, when comparing the
@@ -71,8 +86,6 @@ struct Snapshot {
 	/// Custom variable specified by the user.
 	/// NOTE: The user can specify a different variable depending on the passed GroupSync.
 	VarData custom_data;
-
-	std::vector<ScheduledProcedureExeInfo> pending_scheduled_procedures;
 
 public:
 	operator std::string() const;

--- a/core/snapshot.h
+++ b/core/snapshot.h
@@ -72,7 +72,7 @@ struct Snapshot {
 	/// NOTE: The user can specify a different variable depending on the passed GroupSync.
 	VarData custom_data;
 
-	std::vector<ScheduledProcedureInfo> pending_scheduled_procedures;
+	std::vector<ScheduledProcedureExeInfo> pending_scheduled_procedures;
 
 public:
 	operator std::string() const;

--- a/core/snapshot.h
+++ b/core/snapshot.h
@@ -53,6 +53,7 @@ struct FrameIndexWithMeta {
 
 struct Snapshot {
 	FrameIndex input_id = FrameIndex::NONE;
+	GlobalFrameIndex global_frame_index = GlobalFrameIndex::NONE;
 	std::vector<SimulatedObjectInfo> simulated_objects;
 	/// The Node variables in a particular frame. The order of this vector
 	/// matters because the index is the `ObjectNetId`.

--- a/core/snapshot.h
+++ b/core/snapshot.h
@@ -91,6 +91,7 @@ public:
 	operator std::string() const;
 
 	const std::vector<std::optional<VarData>> *get_object_vars(ObjectNetId p_id) const;
+	const std::vector<ScheduledProcedureSnapshot> *get_object_procedures(ObjectNetId p_id) const;
 
 	/// Copy the given snapshot.
 	static Snapshot make_copy(const Snapshot &p_other);

--- a/core/snapshot.h
+++ b/core/snapshot.h
@@ -2,6 +2,7 @@
 
 #include "core.h"
 #include "object_data.h"
+#include "scheduled_procedure.h"
 #include <map>
 #include <optional>
 
@@ -69,6 +70,8 @@ struct Snapshot {
 	/// Custom variable specified by the user.
 	/// NOTE: The user can specify a different variable depending on the passed GroupSync.
 	VarData custom_data;
+
+	std::vector<ScheduledProcedureInfo> pending_scheduled_procedures;
 
 public:
 	operator std::string() const;

--- a/scene_synchronizer.cpp
+++ b/scene_synchronizer.cpp
@@ -4537,17 +4537,24 @@ void ClientSynchronizer::update_client_snapshot(Snapshot &r_snapshot) {
 		ObjectDataSnapshot *object_data_snap = r_snapshot.objects.data() + od->get_net_id().id;
 		object_data_snap->vars.resize(od->vars.size());
 
-		std::optional<VarData> *snap_node_vars_ptr = object_data_snap->vars.data();
+		std::optional<VarData> *od_snap_vars_ptr = object_data_snap->vars.data();
 		for (std::size_t v = 0; v < od->vars.size(); v += 1) {
 #ifdef NS_PROFILING_ENABLED
 			std::string sub_perf_info = "Var: " + od->vars[v].var.name;
 			NS_PROFILE_NAMED_WITH_INFO("Update object data variable", sub_perf_info);
 #endif
 			if (od->vars[v].enabled) {
-				snap_node_vars_ptr[v].emplace(VarData::make_copy(od->vars[v].var.value));
+				od_snap_vars_ptr[v].emplace(VarData::make_copy(od->vars[v].var.value));
 			} else {
-				snap_node_vars_ptr[v].reset();
+				od_snap_vars_ptr[v].reset();
 			}
+		}
+
+		object_data_snap->procedures.resize(od->get_scheduled_procedures().size());
+		for (std::size_t p = 0; p < od->get_scheduled_procedures().size(); p += 1) {
+			object_data_snap->procedures[p].execute_frame = od->get_scheduled_procedures()[p].execute_frame;
+			object_data_snap->procedures[p].paused_frame = od->get_scheduled_procedures()[p].paused_frame;
+			object_data_snap->procedures[p].args = od->get_scheduled_procedures()[p].args;
 		}
 	}
 

--- a/scene_synchronizer.h
+++ b/scene_synchronizer.h
@@ -1094,11 +1094,12 @@ public:
 			void (*p_notify_update_mode)(void *p_user_pointer, bool p_is_partial_update),
 			void (*p_parse_global_frame_index)(void *p_user_pointer, GlobalFrameIndex p_global_frame_index),
 			void (*p_custom_data_parse)(void *p_user_pointer, VarData &&p_custom_data),
-			void (*p_object_parse)(void *p_user_pointer, NS::ObjectData *p_object_data),
+			void (*p_object_parse)(void *p_user_pointer, ObjectData *p_object_data),
 			// NOTE: The frame index meta is not initialized by this function,
 			// and it's up to the calling function doint it.
 			bool (*p_peers_frame_index_parse)(void *p_user_pointer, std::map<int, FrameIndexWithMeta> &&p_frames_index),
-			void (*p_variable_parse)(void *p_user_pointer, NS::ObjectData *p_object_data, VarId p_var_id, VarData &&p_value),
+			void (*p_variable_parse)(void *p_user_pointer, ObjectData *p_object_data, VarId p_var_id, VarData &&p_value),
+			void (*p_scheduled_procedure_parse)(void *p_user_pointer, ObjectData *p_object_data, ScheduledProcedureId p_procedure_id, ScheduledProcedureSnapshot &&p_value),
 			void (*p_simulated_object_add_or_remove_parse)(void *p_user_pointer, bool p_add, SimulatedObjectInfo &&p_simulated_objects),
 			void (*p_simulated_objects_parse)(void *p_user_pointer, std::vector<SimulatedObjectInfo> &&p_simulated_objects));
 

--- a/scene_synchronizer.h
+++ b/scene_synchronizer.h
@@ -605,7 +605,7 @@ public: // ---------------------------------------------------------------- APIs
 			ObjectLocalId p_id,
 			ScheduledProcedureId p_procedure_id);
 
-	void scheduled_procedure_start(
+	GlobalFrameIndex scheduled_procedure_start(
 			ObjectLocalId p_id,
 			ScheduledProcedureId p_procedure_id,
 			float p_execute_in_seconds);
@@ -615,6 +615,10 @@ public: // ---------------------------------------------------------------- APIs
 			ScheduledProcedureId p_procedure_id);
 
 	void scheduled_procedure_pause(
+			ObjectLocalId p_id,
+			ScheduledProcedureId p_procedure_id);
+	
+	GlobalFrameIndex scheduled_procedure_unpause(
 			ObjectLocalId p_id,
 			ScheduledProcedureId p_procedure_id);
 

--- a/scene_synchronizer.h
+++ b/scene_synchronizer.h
@@ -302,7 +302,7 @@ protected: // -------------------------------------------------------- Internals
 	RpcHandle<bool> rpc_handler_notify_peer_status;
 	RpcHandle<const std::vector<std::uint8_t> &> rpc_handler_trickled_sync_data;
 	RpcHandle<DataBuffer &> rpc_handle_notify_netstats;
-	RpcHandle<ObjectNetId, ScheduledProcedureId, FrameIndex, DataBuffer &> rpc_handle_notify_scheduled_procedure;
+	RpcHandle<ObjectNetId, ScheduledProcedureId, GlobalFrameIndex, DataBuffer &> rpc_handle_notify_scheduled_procedure;
 
 	// Controller RPCs.
 	RpcHandle<int, const std::vector<std::uint8_t> &> rpc_handle_receive_input;
@@ -332,7 +332,7 @@ protected: // -------------------------------------------------------- Internals
 	bool cached_process_functions_valid = false;
 	Processor<float> cached_process_functions[PROCESS_PHASE_COUNT];
 
-	std::vector<ScheduledProcedureInfo> scheduled_procedures_pending_sorted;
+	std::vector<ScheduledProcedureExeInfo> scheduled_procedures_pending_sorted;
 
 	bool debug_rewindings_enabled = false;
 	bool debug_server_speedup = false;
@@ -531,7 +531,7 @@ public: // ---------------------------------------------------------------- RPCs
 	void rpc_notify_peer_status(bool p_enabled);
 	void rpc_trickled_sync_data(const std::vector<std::uint8_t> &p_data);
 	void rpc_notify_netstats(DataBuffer &p_data);
-	void rpc_notify_scheduled_procedure(ObjectNetId p_object_id, ScheduledProcedureId p_scheduled_procedure_id, FrameIndex p_frame_index, DataBuffer &p_data);
+	void rpc_notify_scheduled_procedure(ObjectNetId p_object_id, ScheduledProcedureId p_scheduled_procedure_id, GlobalFrameIndex p_frame_index, DataBuffer &p_data);
 
 	void call_rpc_receive_inputs(int p_recipient, int p_peer, const std::vector<std::uint8_t> &p_data);
 
@@ -603,7 +603,7 @@ public: // ---------------------------------------------------------------- APIs
 			ObjectLocalId p_id,
 			ScheduledProcedureId p_procedure_id);
 
-	void scheduled_procedure_execution(
+	void scheduled_procedure_start(
 			ObjectLocalId p_id,
 			ScheduledProcedureId p_procedure_id,
 			float p_execute_in_seconds);
@@ -667,8 +667,7 @@ public: // ---------------------------------------------------------------- APIs
 	float sync_group_get_trickled_update_rate(ObjectLocalId p_id, SyncGroupId p_group_id) const;
 	float sync_group_get_trickled_update_rate(ObjectNetId p_id, SyncGroupId p_group_id) const;
 
-	// TODO implement this
-	void sync_group_notify_procedure_scheduled(ObjectData *p_object_data, ScheduledProcedureId p_scheduled_procedure_id, GlobalFrameIndex p_frame_index, DataBuffer &p_data);
+	void sync_group_notify_procedure_scheduled(ObjectData &p_object_data, ScheduledProcedureId p_scheduled_procedure_id, GlobalFrameIndex p_frame_index, DataBuffer &p_args);
 
 	void sync_group_set_user_data(SyncGroupId p_group_id, uint64_t p_user_ptr);
 	uint64_t sync_group_get_user_data(SyncGroupId p_group_id) const;
@@ -911,6 +910,8 @@ public:
 
 	void sync_group_set_trickled_update_rate(NS::ObjectData *p_object_data, SyncGroupId p_group_id, float p_update_rate);
 	float sync_group_get_trickled_update_rate(const NS::ObjectData *p_object_data, SyncGroupId p_group_id) const;
+
+	void sync_group_notify_procedure_scheduled(ObjectData &p_object_data, ScheduledProcedureId p_scheduled_procedure_id, GlobalFrameIndex p_frame_index, DataBuffer &p_data);
 
 	void sync_group_set_user_data(SyncGroupId p_group_id, uint64_t p_user_ptr);
 	uint64_t sync_group_get_user_data(SyncGroupId p_group_id) const;

--- a/scene_synchronizer.h
+++ b/scene_synchronizer.h
@@ -307,6 +307,8 @@ protected: // -------------------------------------------------------- Internals
 	// Controller RPCs.
 	RpcHandle<int, const std::vector<std::uint8_t> &> rpc_handle_receive_input;
 
+	GlobalFrameIndex global_frame_index = GlobalFrameIndex{ 0 };
+
 	Settings settings;
 	bool settings_changed = true;
 
@@ -536,6 +538,10 @@ public: // ---------------------------------------------------------------- RPCs
 	void rpc_receive_inputs(int p_peer, const std::vector<std::uint8_t> &p_data);
 
 public: // ---------------------------------------------------------------- APIs
+	GlobalFrameIndex get_global_frame_index() const {
+		return global_frame_index;
+	}
+
 	void set_settings(Settings &p_settings);
 	Settings &get_settings_mutable();
 	const Settings &get_settings() const;
@@ -661,7 +667,8 @@ public: // ---------------------------------------------------------------- APIs
 	float sync_group_get_trickled_update_rate(ObjectLocalId p_id, SyncGroupId p_group_id) const;
 	float sync_group_get_trickled_update_rate(ObjectNetId p_id, SyncGroupId p_group_id) const;
 
-	void sync_group_notify_procedure_scheduled(ObjectData* p_object_data, ScheduledProcedureId p_scheduled_procedure_id, FrameIndex p_frame_index, DataBuffer &p_data);
+	// TODO implement this
+	void sync_group_notify_procedure_scheduled(ObjectData *p_object_data, ScheduledProcedureId p_scheduled_procedure_id, GlobalFrameIndex p_frame_index, DataBuffer &p_data);
 
 	void sync_group_set_user_data(SyncGroupId p_group_id, uint64_t p_user_ptr);
 	uint64_t sync_group_get_user_data(SyncGroupId p_group_id) const;
@@ -1074,6 +1081,7 @@ public:
 			DataBuffer &p_snapshot,
 			void *p_user_pointer,
 			void (*p_notify_update_mode)(void *p_user_pointer, bool p_is_partial_update),
+			void (*p_parse_global_frame_index)(void *p_user_pointer, GlobalFrameIndex p_global_frame_index),
 			void (*p_custom_data_parse)(void *p_user_pointer, VarData &&p_custom_data),
 			void (*p_object_parse)(void *p_user_pointer, NS::ObjectData *p_object_data),
 			// NOTE: The frame index meta is not initialized by this function,

--- a/tests/test_scene_synchronizer.cpp
+++ b/tests/test_scene_synchronizer.cpp
@@ -1159,7 +1159,7 @@ void test_scheduled_procedure() {
 
 	// -------------------------------------------------- SCHEDULE THE PROCEDURE
 	scene_object_on_server->just_a_float_value = 532.f;
-	server_scene.scene_sync->scheduled_procedure_execution(scene_object_on_server->local_id, scene_object_on_server->procedure_id, 0.2f);
+	server_scene.scene_sync->scheduled_procedure_start(scene_object_on_server->local_id, scene_object_on_server->procedure_id, 0.2f);
 
 	// ---------------------------------------------------------- ASSERTION FUNC
 	{
@@ -1503,7 +1503,7 @@ void test_scene_synchronizer() {
 	test_state_notify_for_no_rewind_properties();
 	test_variable_change_event();
 	test_controller_processing();
-	//test_scheduled_procedure();
+	test_scheduled_procedure();
 	test_streaming();
 	test_no_network();
 	test_sync_mode_reset();

--- a/tests/test_scene_synchronizer.cpp
+++ b/tests/test_scene_synchronizer.cpp
@@ -1503,7 +1503,7 @@ void test_scene_synchronizer() {
 	test_state_notify_for_no_rewind_properties();
 	test_variable_change_event();
 	test_controller_processing();
-	test_scheduled_procedure();
+	//test_scheduled_procedure();
 	test_streaming();
 	test_no_network();
 	test_sync_mode_reset();

--- a/tests/test_simulation.cpp
+++ b/tests/test_simulation.cpp
@@ -350,9 +350,11 @@ public:
 		Vec3 controller_server_position_at_target_frame;
 		Vec3 light_mag_server_position_at_target_frame;
 		Vec3 heavy_mag_server_position_at_target_frame;
+		NS::GlobalFrameIndex global_frame_index_on_server;
 		Vec3 controller_p1_position_at_target_frame;
 		Vec3 light_mag_p1_position_at_target_frame;
 		Vec3 heavy_mag_p1_position_at_target_frame;
+		NS::GlobalFrameIndex global_frame_index_on_p1;
 
 		while (true) {
 			// Use a random delta, to make sure the NetSync can be processed
@@ -368,12 +370,14 @@ public:
 				controller_server_position_at_target_frame = controlled_obj_server->get_position();
 				light_mag_server_position_at_target_frame = light_magnet_server->get_position();
 				heavy_mag_server_position_at_target_frame = heavy_magnet_server->get_position();
+				global_frame_index_on_server = server_scene.scene_sync->get_global_frame_index();
 			}
 			if (controller_p1->get_current_frame_index() == process_until_frame) {
 				p1_reached_target_frame = true;
 				controller_p1_position_at_target_frame = controlled_obj_p1->get_position();
 				light_mag_p1_position_at_target_frame = light_magnet_p1->get_position();
 				heavy_mag_p1_position_at_target_frame = heavy_magnet_p1->get_position();
+				global_frame_index_on_p1 = peer_1_scene.scene_sync->get_global_frame_index();
 			}
 
 			if (server_reached_target_frame && p1_reached_target_frame) {
@@ -399,6 +403,7 @@ public:
 		NS_ASSERT_COND(controller_server_position_at_target_frame.distance_to(controller_p1_position_at_target_frame) < 0.0001);
 		NS_ASSERT_COND(light_mag_server_position_at_target_frame.distance_to(light_mag_p1_position_at_target_frame) < 0.0001);
 		NS_ASSERT_COND(heavy_mag_server_position_at_target_frame.distance_to(heavy_mag_p1_position_at_target_frame) < 0.0001);
+		NS_ASSERT_COND(global_frame_index_on_server == global_frame_index_on_p1);
 
 		on_scenes_done();
 	}


### PR DESCRIPTION
The scheduled procedure is a feature that can be used to trigger actions in sync at a specific moment in time during the execution.
This feature can be used to:
1. Create a timer
2. Execute an action in sync with all the peers

The scheduled procedure can be stopped or paused and any peer can query the synchronizer to know the time left for that specific procedure to be executed. This is particularly handy in case it's necessary to show a timeout or cooldown. 