### PR TITLE
This PR fixes a bug causing some objects never being synchronized.

### DIFF
--- a/core/data_buffer.h
+++ b/core/data_buffer.h
@@ -139,6 +139,8 @@ public:
 	void copy(const DataBuffer &p_other);
 	void copy(const BitArray &p_buffer);
 
+	bool slice(DataBuffer &p_destination, int p_offset_in_bits, int p_count_in_bits) const;
+
 	const BitArray &get_buffer() const {
 		return buffer;
 	}

--- a/core/object_data.cpp
+++ b/core/object_data.cpp
@@ -197,6 +197,17 @@ void ObjectData::scheduled_procedure_set_args(ScheduledProcedureId p_id, const D
 	scheduled_procedures[p_id.id].args.copy(p_args);
 }
 
+void ObjectData::scheduled_procedure_reset_to(ScheduledProcedureId p_id, const ScheduledProcedureSnapshot &p_snapshot) {
+	if (p_snapshot.execute_frame.id != 0 && p_snapshot.paused_frame.id == 0) {
+		scheduled_procedure_set_args(p_id, p_snapshot.args);
+		scheduled_procedure_start(p_id, p_snapshot.execute_frame);
+	} else if (p_snapshot.paused_frame.id != 0) {
+		scheduled_procedure_pause(p_id, p_snapshot.execute_frame, p_snapshot.paused_frame);
+	} else {
+		scheduled_procedure_stop(p_id);
+	}
+}
+
 void ObjectData::scheduled_procedure_execute(ScheduledProcedureId p_id, ScheduledProcedurePhase p_phase, const SynchronizerManager &p_sync_manager, SceneSynchronizerDebugger &p_debugger) {
 #ifdef NS_DEBUG_ENABLED
 	NS_ASSERT_COND(!scheduled_procedures[p_id.id].args.is_buffer_failed());

--- a/core/object_data.h
+++ b/core/object_data.h
@@ -135,6 +135,7 @@ public:
 	/// Calls the procedure and initialize the args. This is usually called on the server.
 	void scheduled_procedure_fetch_args(ScheduledProcedureId p_id, const SynchronizerManager &p_sync_manager, SceneSynchronizerDebugger &p_debugger);
 	void scheduled_procedure_set_args(ScheduledProcedureId p_id, const DataBuffer &p_args);
+	void scheduled_procedure_reset_to(ScheduledProcedureId p_id, const struct ScheduledProcedureSnapshot &p_snapshot);
 
 	void scheduled_procedure_execute(ScheduledProcedureId p_id, ScheduledProcedurePhase p_phase, const SynchronizerManager &p_sync_manager, SceneSynchronizerDebugger &p_debugger);
 

--- a/core/object_data_storage.cpp
+++ b/core/object_data_storage.cpp
@@ -187,7 +187,7 @@ const std::map<int, std::vector<ObjectData *>> &ObjectDataStorage::get_peers_con
 }
 
 const std::vector<ObjectData *> *ObjectDataStorage::get_peer_controlled_objects_data(int p_peer) const {
-	return NS::MapFunc::get_or_null(objects_data_controlled_by_peers, p_peer);
+	return MapFunc::get_or_null(objects_data_controlled_by_peers, p_peer);
 }
 
 const std::vector<ObjectData *> &ObjectDataStorage::get_unnamed_objects_data() const {

--- a/tests/test_data_buffer.cpp
+++ b/tests/test_data_buffer.cpp
@@ -1059,6 +1059,23 @@ void test_data_buffer_slice_copy() {
 		NS_ASSERT_COND(slice.read_bool()== true);
 		NS_ASSERT_COND(slice.read_bool()== false);
 	}
+
+	origin_buffer.add(false);
+	origin_buffer.add(false);
+	origin_buffer.add(false);
+	origin_buffer.add(false);
+	origin_buffer.add(std::uint8_t(254));
+
+	{
+		NS::DataBuffer slice;
+		slice.begin_write(debugger, 0);
+		NS_ASSERT_COND(origin_buffer.slice(slice, 40, 8));
+		NS_ASSERT_COND(!origin_buffer.is_buffer_failed());
+		NS_ASSERT_COND(origin_buffer.get_bit_offset()==current_offset + 12);
+
+		slice.begin_read(debugger);
+		NS_ASSERT_COND(slice.read_uint(NS::DataBuffer::COMPRESSION_LEVEL_3)== 254);
+	}
 }
 
 void NS_Test::test_data_buffer() {

--- a/tests/test_data_buffer.cpp
+++ b/tests/test_data_buffer.cpp
@@ -989,6 +989,78 @@ void test_data_buffer_reading_failing() {
 	}
 }
 
+void test_data_buffer_slice_copy() {
+	NS::DataBuffer origin_buffer;
+
+	const int first_integer = 12931237123123;
+	const int second_integer = 1998237123123;
+
+	origin_buffer.begin_write(debugger, 0);
+	origin_buffer.add(true);
+	origin_buffer.add(false);
+	origin_buffer.add(first_integer);
+	origin_buffer.add(true);
+	origin_buffer.add(false);
+
+	NS_ASSERT_COND(!origin_buffer.is_buffer_failed());
+	const int current_offset = origin_buffer.get_bit_offset();
+
+	{
+		NS::DataBuffer slice;
+		slice.begin_write(debugger, 0);
+		NS_ASSERT_COND(origin_buffer.slice(slice, 0, 2));
+		NS_ASSERT_COND(!origin_buffer.is_buffer_failed());
+		NS_ASSERT_COND(origin_buffer.get_bit_offset()==current_offset);
+
+		slice.begin_read(debugger);
+		NS_ASSERT_COND(slice.read_bool()== true);
+		NS_ASSERT_COND(slice.read_bool()== false);
+	}
+
+	{
+		NS::DataBuffer slice;
+		slice.begin_write(debugger, 0);
+		NS_ASSERT_COND(origin_buffer.slice(slice, 2, 32));
+		NS_ASSERT_COND(!origin_buffer.is_buffer_failed());
+		NS_ASSERT_COND(origin_buffer.get_bit_offset()==current_offset);
+
+		slice.begin_read(debugger);
+		NS_ASSERT_COND(slice.read_int(NS::DataBuffer::COMPRESSION_LEVEL_1)== first_integer);
+	}
+
+	{
+		NS::DataBuffer slice;
+		slice.begin_write(debugger, 0);
+		NS_ASSERT_COND(origin_buffer.slice(slice, 34, 2));
+		NS_ASSERT_COND(!origin_buffer.is_buffer_failed());
+		NS_ASSERT_COND(origin_buffer.get_bit_offset()==current_offset);
+
+		slice.begin_read(debugger);
+		NS_ASSERT_COND(slice.read_bool()== true);
+		NS_ASSERT_COND(slice.read_bool()== false);
+	}
+
+	{
+		NS::DataBuffer slice;
+		slice.begin_write(debugger, 0);
+		slice.add(true);
+		slice.add(false);
+		slice.add(second_integer);
+
+		NS_ASSERT_COND(origin_buffer.slice(slice, 2, 34));
+		NS_ASSERT_COND(!origin_buffer.is_buffer_failed());
+		NS_ASSERT_COND(origin_buffer.get_bit_offset()==current_offset);
+
+		slice.begin_read(debugger);
+		NS_ASSERT_COND(slice.read_bool()== true);
+		NS_ASSERT_COND(slice.read_bool()== false);
+		NS_ASSERT_COND(slice.read_int(NS::DataBuffer::COMPRESSION_LEVEL_1)== second_integer);
+		NS_ASSERT_COND(slice.read_int(NS::DataBuffer::COMPRESSION_LEVEL_1)== first_integer);
+		NS_ASSERT_COND(slice.read_bool()== true);
+		NS_ASSERT_COND(slice.read_bool()== false);
+	}
+}
+
 void NS_Test::test_data_buffer() {
 	test_data_buffer_string();
 	test_data_buffer_u16string();
@@ -1017,4 +1089,5 @@ void NS_Test::test_data_buffer() {
 	test_data_buffer_writing_failing();
 	test_data_buffer_reading_failing();
 	test_data_buffer_unaligned_write_read();
+	test_data_buffer_slice_copy();
 }


### PR DESCRIPTION
This PR fixes a nasty bug that caused some objects to never synchronize. The issue occurred when an object was spawned after the client received the initial snapshot, as the snapshot data was entirely discarded.

This fix resolves the bug and ensures that objects can be spawned at any moment in time.