### PR TITLE
Fixes the bug that was preventing the NoRewind vars from being set and improves the ScheduledProcedure restore.

### DIFF
--- a/scene_synchronizer.h
+++ b/scene_synchronizer.h
@@ -1207,7 +1207,8 @@ public:
 			const bool p_skip_simulated_objects_update = false,
 			const bool p_disable_apply_non_doll_controlled_only = false,
 			const bool p_skip_snapshot_applied_event_broadcast = false,
-			const bool p_skip_change_event = false);
+			const bool p_skip_change_event = false,
+			const bool p_skip_scheduled_procedures = false);
 };
 
 /// This is used to make sure we can safely convert any `BaseType` defined by


### PR DESCRIPTION
This PR fixes a bug that was causing the variables marked as "Skip Rewind" not to be set on the client and changes  the way the ScheduledProcedure are handled.

The Scheduled Procedure are information about some process to be executed in future, so doesn't make sense to trigger a rewind if the client didn't receive that info yet since we would rewind for an information that will likely have 0 impact on the current rewind. For this reason now the procedure is restored on the client, if missing, without causing any rewind.

Adds some more integration tests.